### PR TITLE
fixed code coverage issue with webpack introduction

### DIFF
--- a/build/karma.conf.ts
+++ b/build/karma.conf.ts
@@ -14,9 +14,21 @@ import * as webpackConfig from './webpack.conf';
  */
 module.exports = (config: karma.Config) => {
   // load webpack config settings
-  let webpackSettings: webpack.Configuration = new webpackConfig.WebPackConfig();
+  // note: at present the webpack.d.ts typedef is outdated at 1.12.2 when webpack
+  //    is at 1.12.9 & includes support for postLoaders on a module... can't qualify
+  //    the typedef for the config because it breaks TypeScript compilation
+  //    > hopefully this can get updated later... see this logged issue for info:
+  //    https://github.com/DefinitelyTyped/DefinitelyTyped/issues/7497
+  let webpackSettings: any = new webpackConfig.WebPackConfig();
   webpackSettings.entry = {};
   webpackSettings.devtool = 'inline-source-map';
+  // use istanbul-instrumenter-loader which deals with webpack-added wrapper code
+  //  that we can't test for
+  webpackSettings.module.postLoaders = [{
+    exclude: /(node_modules|.spec.js)/,
+    loader: 'istanbul-instrumenter',
+    test: /\.js$/
+  }];
 
   // create karma config
   let karmaConfig: IKarmaConfig = <IKarmaConfig>{
@@ -40,9 +52,7 @@ module.exports = (config: karma.Config) => {
     plugins: ['karma-*'],
     port: 5793,
     preprocessors: {
-      'src/**/*.js': ['webpack', 'sourcemap'],
-      'src/core/**/*.js': 'coverage',
-      'src/components/*/!(*spec).js': 'coverage'
+      'src/**/*.js': ['webpack', 'sourcemap']
     },
     reporters: ['progress', 'coverage'],
     singleRun: false,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-util": "^3.0.7",
     "gulp-webpack": "^1.5.0",
     "istanbul": "^0.4.1",
+    "istanbul-instrumenter-loader": "^0.1.3",
     "jasmine-core": "^2.4.1",
     "jquery": "^2.1.4",
     "karma": "^0.13.15",


### PR DESCRIPTION
Webpack adds wrapper code to polyfill the module loading code for environments that don't support modules. This is code that we don't write, so we can't test it, yet the fact it's not covered by our tests lowers the coverage %. Specifically for files with very little code (`core.ts` & `components.ts`) it results in a very low coverage %. This commit adds a webpack loader that addresses this & updates the `karma.config.ts` to use this isntead of the default coverage reporter.

closes #52
