### PR TITLE
Initial version of the spinner component directive

### DIFF
--- a/src/components/spinner/demo/index.html
+++ b/src/components/spinner/demo/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>ngOfficeUiFabric | uif-Spinner demo</title>
+  <meta charset="utf-8">
+  <!-- office ui fabric css -->
+  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.1.3/fabric.min.css" />
+  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.1.3/fabric.components.min.css" />
+  <!-- angular library -->
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.min.js"></script>
+  <!-- ngofficeuifabric library -->
+  <script src="../../../../dist/ngOfficeUiFabric.min.js"></script>
+  <script src="index.js"></script>
+</head>
+
+<body ng-app="demoApp">
+  <h1 class="ms-font-su">Spinner Demo | &lt;uif-spinner&gt;</h1>
+  <em>In order for this demo to work you must first build the library in debug mode.</em>
+
+  <p>To render spinner, use the following markup:
+    <br />
+    <code>
+      &lt;uif-spinner&gt;&lt;uif-spinner/&gt;
+    </code>
+  </p>
+
+  <p>
+    Example:
+    <br />
+    <uif-spinner></uif-spinner>
+  </p>
+
+  <p>To render large spinner, use the following markup:
+    <br />
+    <code>
+      &lt;uif-spinner uif-spinnersize="large"&gt;&lt;uif-spinner/&gt;
+    </code>
+  </p>
+
+  <p>
+    Example:
+    <br />
+    <uif-spinner uif-spinnersize="large"></uif-spinner>
+  </p>
+
+  <p>You can also add content to the spinner, which will become it's label :
+    <br />
+    <code>
+      &lt;uif-spinner uif-spinnersize="large"&gt;Loading...&lt;uif-spinner/&gt;
+    </code>
+  </p>
+
+  <p>
+    Example:
+    <br />
+    <uif-spinner uif-spinnersize="large">Loading...</uif-spinner>
+  </p>
+
+  <p>You can control visibility of the spinner with <code>ngShow</code> directive
+    <br />
+    <code>
+      &lt;uif-spinner uif-spinnersize="large" ng-show="spinnerVisible"&gt;&lt;uif-spinner/&gt;
+    </code>
+  </p>
+
+  <p ng-controller="spinnerDemoController">
+    Example:
+    <br />
+    <button type="button" ng-click="vm.spinnerVisible = !vm.spinnerVisible">Toggle visibility</button>
+    <br />
+    <uif-spinner uif-spinnersize="large" ng-show="vm.spinnerVisible"></uif-spinner>
+  </p>
+
+</body>
+
+</html>

--- a/src/components/spinner/demo/index.js
+++ b/src/components/spinner/demo/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var demoApp = angular.module('demoApp', [
+  'officeuifabric.core',
+  'officeuifabric.components.spinner'
+]);
+
+demoApp.controller('spinnerDemoController',['$scope', spinnerDemoController]);
+
+function spinnerDemoController($scope){
+  $scope.vm = {
+    spinnerVisible: false
+  };
+}

--- a/src/components/spinner/demoBasicUsage/index.html
+++ b/src/components/spinner/demoBasicUsage/index.html
@@ -1,0 +1,1 @@
+<uif-spinner></uif-spinner>

--- a/src/components/spinner/spinnerDirective.spec.ts
+++ b/src/components/spinner/spinnerDirective.spec.ts
@@ -1,0 +1,157 @@
+'use strict';
+
+import * as ng from 'angular';
+
+describe('spinnerDirective', () => {
+  beforeEach(() => {
+    angular.mock.module('officeuifabric.core');
+    angular.mock.module('officeuifabric.components.spinner');
+  });
+
+  describe('basic tests', () => {
+    let element: ng.IAugmentedJQuery;
+    let scope: ng.IScope;
+
+    beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: Function) => {
+      element = ng.element('<uif-spinner></uif-spinner>');
+      scope = $rootScope;
+      $compile(element)(scope);
+      scope.$digest();
+    }));
+
+    it('should render as div', () => {
+      expect(element[0].tagName === 'DIV').toBe(true);
+    });
+
+    it('should render proper CSS class', () => {
+      expect(element[0]).toHaveClass('ms-Spinner');
+    });
+
+    it('should render proper CSS for large spinner', inject(($compile: Function) => {
+      // override default element for suite
+      element = ng.element('<uif-spinner uif-spinnersize="large"></uif-spinner>');
+      $compile(element)(scope);
+      scope.$digest();
+
+      expect(element[0]).toHaveClass('ms-Spinner--large');
+    }));
+
+    it('should not render CSS for large spinner if spinnersize not large', inject(($compile: Function) => {
+      // override default element for suite
+      element = ng.element('<uif-spinner uif-spinnersize="small"></uif-spinner>');
+      $compile(element)(scope);
+      scope.$digest();
+
+      expect(element[0]).not.toHaveClass('ms-Spinner--large');
+    }));
+
+    it('should not render wrapper when no content', () => {
+      let wrapperElement: ng.IAugmentedJQuery = element.find('div.ms-Spinner-label');
+
+      expect(wrapperElement.length).toBe(0);
+    });
+
+    it('should wrap content in div with proper CSS', inject(($compile: Function) => {
+      element = ng.element('<uif-spinner>This should be wrapped!</uif-spinner>');
+      $compile(element)(scope);
+      scope.$digest();
+
+      let wrapperElement: ng.IAugmentedJQuery = element.find('div.ms-Spinner-label');
+      expect(wrapperElement.length).toBeGreaterThan(0);
+      expect(wrapperElement[0].tagName).toEqual('DIV');
+      expect(wrapperElement[0]).toHaveClass('ms-Spinner-label');
+      expect(wrapperElement[0].innerText).toEqual('This should be wrapped!');
+    }));
+
+    it('should have eight circles rendered with proper CSS', () => {
+      let circles: ng.IAugmentedJQuery = element.find('div.ms-Spinner-circle');
+
+      expect(circles.length).toBe(8);
+    });
+
+    it('should have initial opacity on circles set', () => {
+      let circles: ng.IAugmentedJQuery = element.find('div.ms-Spinner-circle');
+
+      expect(circles.css('opacity')).toBeGreaterThan(0);
+    });
+
+  });
+
+  describe('visibility', () => {
+    let element: ng.IAugmentedJQuery;
+    let scope: any;
+
+    beforeEach(inject(($rootScope: ng.IRootScopeService) => {
+      scope = $rootScope.$new();
+      scope.isVisible = false;
+    }));
+
+    it('should change visibility after scope value change', inject(($compile: Function) => {
+      element = ng.element('<uif-spinner ng-show="isVisible"></uif-spinner>');
+      $compile(element)(scope);
+      scope.$digest();
+
+      expect(element[0]).toHaveClass('ng-hide');
+
+      scope.isVisible = true;
+      scope.$apply();
+
+      expect(element[0]).not.toHaveClass('ng-hide');
+    }));
+
+    it('should animate circles when ng-show not set', inject(($compile: Function, $interval: ng.IIntervalService) => {
+      element = ng.element('<uif-spinner></uif-spinner>');
+      $compile(element)(scope);
+      scope.$digest();
+
+      let circles: ng.IAugmentedJQuery = element.find('div.ms-Spinner-circle');
+      let initialOpacity: number = +(circles[0].style.opacity);
+
+      $interval.flush(90);
+
+      let finalOpacity: number = +(circles[0].style.opacity);
+
+      expect(finalOpacity).toBeGreaterThan(initialOpacity);
+    }));
+
+    it('should start/stop animation on ng-show change', inject(($compile: Function, $interval: ng.IIntervalService) => {
+      scope.spinnerVisible = false;
+
+      element = ng.element('<uif-spinner ng-show="spinnerVisible"></uif-spinner>');
+      $compile(element)(scope);
+      scope.$digest();
+
+      let circles: ng.IAugmentedJQuery = element.find('div.ms-Spinner-circle');
+
+      // animation not playing
+      let initialOpacity: number = +(circles[0].style.opacity);
+
+      $interval.flush(90);
+
+      let finalOpacity: number = +(circles[0].style.opacity);
+      expect(finalOpacity === initialOpacity).toBeTruthy();
+
+      // start animation
+      scope.spinnerVisible = true;
+      scope.$digest();
+
+      $interval.flush(90);
+
+      finalOpacity = +(circles[0].style.opacity);
+      expect(finalOpacity > initialOpacity).toBeTruthy();
+
+      // stop animation
+      initialOpacity = +(circles[0].style.opacity);
+
+      scope.spinnerVisible = false;
+      scope.$digest();
+
+      $interval.flush(90);
+
+      finalOpacity = +(circles[0].style.opacity);
+      expect(finalOpacity === initialOpacity).toBeTruthy();
+    }));
+
+  });
+
+});

--- a/src/components/spinner/spinnerDirective.ts
+++ b/src/components/spinner/spinnerDirective.ts
@@ -1,0 +1,219 @@
+'use strict';
+import * as ng from 'angular';
+
+/**
+ * @ngdoc directive
+ * @name uifSpinner
+ * @module officeuifabric.components.spinner
+ *
+ * @restrict E
+ *
+ * @description
+ *
+ * `<uif-spinner>` is a spinner directive.
+ *
+ * @see {link http://dev.office.com/fabric/components/}
+ *
+ * @usage
+ *
+ * <uif-spinner></uif-Spinner>
+ */
+
+export class SpinnerDirective implements ng.IDirective {
+  public restrict: string = 'E';
+  public transclude: boolean = true;
+  public replace: boolean = true;
+  public template: string = '<div class="ms-Spinner"></div>';
+  public controller: any = SpinnerController;
+  public scope: any = {
+    'ngShow': '='
+  };
+
+  public static factory(): ng.IDirectiveFactory {
+    const directive: ng.IDirectiveFactory = () => new SpinnerDirective();
+    return directive;
+  }
+
+  public link(
+    scope: ISpinnerScope,
+    instanceElement: ng.IAugmentedJQuery,
+    attrs: ISpinnerAttributes,
+    ctrl: any,
+    $transclude: ng.ITranscludeFunction): void {
+
+      if (attrs.uifSpinnersize === 'large') {
+        instanceElement.addClass('ms-Spinner--large');
+      }
+
+      if (attrs.ngShow != null) {
+        scope.$watch('ngShow', (newVisible: boolean, oldVisible: boolean, spinnerScope: ISpinnerScope): void => {
+            if (newVisible) {
+              spinnerScope.start();
+            } else {
+              spinnerScope.stop();
+            }
+        });
+      } else {
+        scope.start();
+      }
+
+      $transclude((clone: ng.IAugmentedJQuery) => {
+        if (clone.length > 0) {
+          let wrapper: ng.IAugmentedJQuery = ng.element('<div></div>');
+          wrapper.addClass('ms-Spinner-label').append(clone);
+          instanceElement.append(wrapper);
+        }
+      });
+  }
+}
+
+/**
+ * @ngdoc interface
+ * @name ISpinnerScope
+ * @module officeuifabric.components.spinner
+ *
+ * @description
+ * This is the scope used by the directive.
+ *
+ * @property {function} start     - Function strating the spinner animation. Called when spinner is being set to visivle state.
+ * @property {function} stop      - Function stopping spinner animation. Called when spinner is being hidden.
+ * @property {boolean} ngShow     - Controls visibility of the spinner and triggers animation start/top on change.
+ */
+interface ISpinnerScope extends ng.IScope {
+  start: () => void;
+  stop: () => void;
+  ngShow: boolean;
+}
+
+/**
+ * @ngdoc object
+ * @name SpinnerController
+ * @requires  $scope, $element, $interval
+ * @description
+ * Spnner directive controller. Used to initialize the spinner element and controls the animation of the spinner.
+ */
+class SpinnerController {
+
+  public static $inject: string[] = ['$scope', '$element', '$interval'];
+
+  private _offsetSize: number = 0.179;
+  private _numCircles: number = 8;
+  private _animationSpeed: number = 90;
+  private _circles: CircleObject[] = [];
+  private _fadeIncrement: number;
+  private _animationInterval: ng.IPromise<any>;
+
+  constructor(
+    public $scope: ISpinnerScope,
+    private $element: ng.IAugmentedJQuery,
+    private $interval: ng.IIntervalService) {
+
+    this.createCirclesAndArrange();
+    this.setInitialOpacity();
+
+    $scope.start = (): void => {
+      this._animationInterval = $interval(
+      () => {
+        let i: number = this._circles.length;
+        while (i--) {
+          this.fadeCircle(this._circles[i]);
+        }
+       },
+      this._animationSpeed);
+    };
+
+    $scope.stop = (): void => {
+      $interval.cancel(this._animationInterval);
+    };
+  }
+
+  private createCirclesAndArrange(): void {
+
+    let width: number = this.$element[0].clientWidth;
+    let height: number = this.$element[0].clientHeight;
+    let angle: number = 0;
+    let offset: number = width * this._offsetSize;
+    let step: number = (2 * Math.PI) / this._numCircles;
+    let i: number = this._numCircles;
+    let radius: number = (width - offset) * 0.5;
+
+    while (i--) {
+      let circle: ng.IAugmentedJQuery = this.createCircle();
+
+      this.$element.append(circle);
+
+      let x: number = Math.round(width * 0.5 + radius * Math.cos(angle) - circle[0].clientWidth * 0.5) - offset * 0.5;
+      let y: number = Math.round(height * 0.5 + radius * Math.sin(angle) - circle[0].clientHeight * 0.5) - offset * 0.5;
+
+      circle.css('left', (x + 'px'));
+      circle.css('top', (y + 'px'));
+
+      angle += step;
+
+      let circleObject: CircleObject = new CircleObject(circle, i);
+      this._circles.push(circleObject);
+    }
+  }
+
+  private createCircle(): ng.IAugmentedJQuery {
+    let circle: ng.IAugmentedJQuery = ng.element('<div></div>');
+    let parentWidth: number = this.$element[0].clientWidth;
+    let dotSize: string = (parentWidth * this._offsetSize) + 'px';
+
+    circle.addClass('ms-Spinner-circle').css('width', dotSize).css('height', dotSize);
+
+    return circle;
+  };
+
+  private setInitialOpacity(): void {
+
+        let opcaityToSet: number;
+        this._fadeIncrement = 1 / this._numCircles;
+
+        this._circles.forEach((circle: CircleObject, index: number) => {
+          opcaityToSet = (this._fadeIncrement * (index + 1));
+          circle.opacity = opcaityToSet;
+        });
+  }
+
+  private fadeCircle(circle: CircleObject): void {
+    let newOpacity: number = circle.opacity - this._fadeIncrement;
+
+    if (newOpacity <= 0) {
+      newOpacity = 1;
+    }
+
+    circle.opacity = newOpacity;
+  }
+
+}
+
+class CircleObject {
+  constructor(
+    public circleElement: ng.IAugmentedJQuery,
+    public circleIndex: number) {
+  }
+
+  public get opacity(): number {
+    return +(this.circleElement.css('opacity'));
+  }
+
+  public set opacity(opacity: number) {
+    this.circleElement.css('opacity', opacity);
+  }
+}
+
+interface ISpinnerAttributes extends ng.IAttributes {
+  uifSpinnersize?: string;
+  ngShow?: any;
+}
+
+/**
+ * @ngdoc module
+ * @name officeuifabric.components.spinner
+ *
+ * @description
+ * Spinner
+ */
+export var module: ng.IModule = ng.module('officeuifabric.components.spinner', ['officeuifabric.components'])
+  .directive('uifSpinner', SpinnerDirective.factory());

--- a/src/core/components.ts
+++ b/src/core/components.ts
@@ -3,18 +3,20 @@
 import * as ng from 'angular';
 import * as iconModule from '../components/icon/iconDirective';
 import * as textFieldModule from '../components/textfield/textFieldDirective';
+import * as spinnerModule from '../components/spinner/spinnerDirective';
 
 
 /**
  * @ngdoc module
  * @name officeuifabric.components
- * 
- * @description 
- * Office UI Fabric Angular directives components module that includes all 
+ *
+ * @description
+ * Office UI Fabric Angular directives components module that includes all
  * other directives within the library.
- * 
+ *
  */
 export var module: ng.IModule = ng.module('officeuifabric.components', [
     iconModule.module.name,
-    textFieldModule.module.name
+    textFieldModule.module.name,
+    spinnerModule.module.name
   ]);


### PR DESCRIPTION
I believe I have finished the first version of the spinner component.

You will notice that for spinner with label, spinner is over the message. However it looks the same if I setup a codepen example for it [here](http://codepen.io/jjczopek/pen/bEBOWg).

I manually ported functionality of [spinner.js](https://github.com/OfficeDev/Office-UI-Fabric/blob/master/src/components/Spinner/Spinner.js) file into the directive controller. Need to decide whether we should fix that or wait for new Fabric releases and adjust to that.

Closes #35 
