### PR TITLE
Added support to auto- vet\tets\build on file change.

### DIFF
--- a/build/global.d.ts
+++ b/build/global.d.ts
@@ -1,7 +1,7 @@
 /**
  * General purpose interface for callbacks that have no parameters or return types.
  * Commonly used in gulp tasks.
- * 
+ *
  * @callback VoidCallback
  */
 interface IVoidCallback {
@@ -11,7 +11,7 @@ interface IVoidCallback {
 /**
  * General purpose interface for callbacks that have a single string parameter or return types.
  * Commonly used in gulp tasks.
- * 
+ *
  * @callback IStringCallback
  */
 interface IStringCallback {
@@ -20,17 +20,19 @@ interface IStringCallback {
 
 /**
  * Command line arguments.
- * 
+ *
  * @typedef commandLineArgs
  * @type {Object}
  * @property {boolean}  debug     - Flag if Node process should start in debug mode.
  * @property {boolean}  specs     - Flag indicating if the tests should be written to the console.
  * @property {boolean}  verbose   - Flag if tasks should output verbose messages to console.
  * @property {number}   version   - Version number to use in building library, overriding what's in package.json.
+ * @property {boolean}  dev       - Flag indicating if development package should be created (unminified, with comments and sourcemaps)
  */
 interface ICommandLineArgs {
   debug?: boolean;
   specs?: boolean;
   verbose?: boolean;
   version?: number;
+  dev?: boolean;
 }

--- a/build/gulp/tasks/build-lib.ts
+++ b/build/gulp/tasks/build-lib.ts
@@ -11,7 +11,7 @@ let $: any = require('gulp-load-plugins')({ lazy: true });
 
 /**
  * Builds files to be distributed as a library release.
- * 
+ *
  * @class
  */
 export class GulpTask extends BaseGulpTask {
@@ -24,7 +24,7 @@ export class GulpTask extends BaseGulpTask {
   /**
    * @property  {string[]}  dependencies  - Array of all tasks that should be run before this one.
    */
-  public static dependencies: string[] = [];
+  public static dependencies: string[] = ['test'];
 
   /**
    * @property  {string[]}  aliases   - Different options to run the task.
@@ -35,7 +35,7 @@ export class GulpTask extends BaseGulpTask {
    * @property  {Object}  options   - Any command line flags that can be passed to the task.
    */
   public static options: any = {
-    'debug': 'Create unminified version of the library with source maps & comments (otherwise, production bundle created)',
+    'dev': 'Create unminified version of the library with source maps & comments (otherwise, production bundle created)',
     'verbose': 'Output all TypeScript files being compiled & JavaScript files included in the external library',
     'version': 'Version number to set build library (if omitted, version from package.json is used)'
   };
@@ -54,8 +54,8 @@ export class GulpTask extends BaseGulpTask {
     let config: webpack.Configuration = new webpackConfig.WebPackConfig();
 
     let webpackPlugins: webpack.Plugin[] = [];
-    // if debug mode, write source maps & keep comments
-    if (!this._args.debug) {
+    // if dev mode, write source maps & keep comments
+    if (!this._args.dev) {
       config.output.filename = BuildConfig.OUTPUT_LIB_NAME + '.min.js';
       // use uglify plugin to remove comments & sourcemaps
       webpackPlugins.push(

--- a/build/gulp/tasks/transpile-ts.ts
+++ b/build/gulp/tasks/transpile-ts.ts
@@ -8,7 +8,7 @@ let $: any = require('gulp-load-plugins')({ lazy: true });
 
 /**
  * Transpiles all TypeScript as JavaScript as the gulp task 'transpile-ts'.
- * 
+ *
  * @class
  */
 export class GulpTask extends BaseGulpTask {
@@ -22,6 +22,11 @@ export class GulpTask extends BaseGulpTask {
    * @property  {string[]}  aliases   - Different options to run the task.
    */
   public static aliases: string[] = ['tts'];
+
+  /**
+   * @property  {string[]}  dependencies  - Array of all tasks that should be run before this one.
+   */
+  public static dependencies: string[] = ['vet'];
 
   /**
    * @property  {Object}  options   - Any command line flags that can be passed to the task.
@@ -40,7 +45,7 @@ export class GulpTask extends BaseGulpTask {
     super();
     Utils.log('Transpiling app TypeScript files to JavaScript');
 
-    // use the TypeScript project config file for all settings 
+    // use the TypeScript project config file for all settings
     let tsProject: any = $.typescript.createProject('tsconfig.json');
 
     // compile all TypeScript files, including sourcemaps inline in the generated JavaScript

--- a/build/gulp/tasks/vet-build-ts.ts
+++ b/build/gulp/tasks/vet-build-ts.ts
@@ -9,7 +9,7 @@ let $: any = require('gulp-load-plugins')({ lazy: true });
 
 /**
  * Vets the code style & quality of all build-related TypeScript as the gulp task 'vet-build-ts'.
- * 
+ *
  * @class
  */
 export class GulpTask extends BaseGulpTask {
@@ -37,12 +37,10 @@ export class GulpTask extends BaseGulpTask {
     super();
     Utils.log('Vetting build TypeScript code');
 
-    gulp.src(BuildConfig.BUILD_TYPESCRIPT)
+    return gulp.src(BuildConfig.BUILD_TYPESCRIPT)
       .pipe($.if(this._args.verbose, $.print()))
       .pipe($.tslint())
       .pipe($.tslint.report('verbose', { summarizeFailureOutput: true }));
-
-    done();
   }
 
 }

--- a/build/gulp/tasks/vet-lib-ts.ts
+++ b/build/gulp/tasks/vet-lib-ts.ts
@@ -9,7 +9,7 @@ let $: any = require('gulp-load-plugins')({ lazy: true });
 
 /**
  * Vets the code style & quality of all library related TypeScript as the gulp task 'vet-lib-ts'.
- * 
+ *
  * @class
  */
 export class GulpTask extends BaseGulpTask {
@@ -39,12 +39,10 @@ export class GulpTask extends BaseGulpTask {
 
     let allTypeScript: string[] = BuildConfig.LIB_TYPESCRIPT.concat(BuildConfig.LIB_TEST_TYPESCRIPT);
 
-    gulp.src(allTypeScript)
+    return gulp.src(allTypeScript)
       .pipe($.if(this._args.verbose, $.print()))
       .pipe($.tslint())
       .pipe($.tslint.report('verbose', { summarizeFailureOutput: true }));
-
-    done();
   }
 
 }

--- a/build/gulp/tasks/watch.ts
+++ b/build/gulp/tasks/watch.ts
@@ -1,0 +1,74 @@
+'use strict';
+
+import {BaseGulpTask} from '../BaseGulpTask';
+import {Utils} from '../utils';
+import * as gulp from 'gulp';
+import * as path from 'path';
+import * as yargs from 'yargs';
+
+/**
+ * Watches for file change and automatically run vet, test, transpile, build.
+ *
+ * @class
+ */
+export class GulpTask extends BaseGulpTask {
+
+  /**
+   * @property  {string}  description   - Help description for the task.
+   */
+  public static description: string = 'Watches for changes in files and automatically runs vet, build, test';
+
+  /**
+   * @property  {string[]}  dependencies  - Array of all tasks that should be run before this one.
+   */
+  public static dependencies: string[] = [];
+
+  /**
+   * @property  {string[]}  aliases   - Different options to run the task.
+   */
+  public static aliases: string[] = ['ld', 'LD'];
+
+  /**
+   * @property  {Object}  options   - Any command line flags that can be passed to the task.
+   */
+  public static options: any = {
+    'specs': 'Affects \'test\' task, outputs all tests being run',
+    'verbose': 'Affects \'test\' and \'build-lib\' tasks, outputs all TypeScript files ' +
+                'being compiled & JavaScript files included in the external library, set karma log level to INFO',
+    'version': 'Affects \'build-lib\' task, version number to set build library (if omitted, version from package.json is used)',
+    'debug': 'Affects \'test\' task, sets karma log level to DEBUG',
+    'dev': 'Affects \'build-lib\' task, creates unminified version of the library ' +
+            'with source maps & comments (otherwise, production bundle created) '
+  };
+
+  /**
+   * @property  {ICommandLineArgs}  args  - Command line arguments;
+   */
+  private _args: ICommandLineArgs = yargs.argv;
+
+  /** @constructor */
+  constructor() {
+    super();
+    Utils.log('Watching for files changes....');
+
+    let logEvent: (event: gulp.WatchEvent, eventName: string) => void = (event: gulp.WatchEvent, eventName: string) => {
+      let fileName: string = path.basename(event.path);
+      Utils.log(`*** Event: '${eventName}'. Triggered by file: '${fileName}' ***`);
+    };
+
+    let subscribeWatcher: (watcher: NodeJS.EventEmitter, eventName: string) => void = (watcher: NodeJS.EventEmitter, eventName: string) => {
+      watcher.on('change', (event: gulp.WatchEvent) => {
+        logEvent(event, eventName);
+      });
+    };
+
+    let buildLibEventName: string = 'Build library in DEV mode';
+    if (!this._args.dev) {
+      buildLibEventName = 'Build library in RELEASE mode';
+    }
+
+    subscribeWatcher(gulp.watch(['./src/**/*.ts', '!./src/**/*.spec.ts'], ['build-lib']), buildLibEventName);
+    subscribeWatcher(gulp.watch(['./build/**/*.ts', './gulpfile.ts'], ['transpile-ts']), 'Transpile build files');
+    subscribeWatcher(gulp.watch(['./src/**/*.spec.ts'], ['test']), 'Run tests');
+  }
+}

--- a/build/gulp/tasks/watch.ts
+++ b/build/gulp/tasks/watch.ts
@@ -26,7 +26,7 @@ export class GulpTask extends BaseGulpTask {
   /**
    * @property  {string[]}  aliases   - Different options to run the task.
    */
-  public static aliases: string[] = ['ld', 'LD'];
+  public static aliases: string[] = ['w', 'W'];
 
   /**
    * @property  {Object}  options   - Any command line flags that can be passed to the task.

--- a/build/gulp/tasks/watch.ts
+++ b/build/gulp/tasks/watch.ts
@@ -68,7 +68,7 @@ export class GulpTask extends BaseGulpTask {
     }
 
     subscribeWatcher(gulp.watch(['./src/**/*.ts', '!./src/**/*.spec.ts'], ['build-lib']), buildLibEventName);
-    subscribeWatcher(gulp.watch(['./build/**/*.ts', './gulpfile.ts'], ['transpile-ts']), 'Transpile build files');
+    subscribeWatcher(gulp.watch(['./build/**/*.ts', './gulpfile.ts', './config/**/*.ts'], ['transpile-ts']), 'Transpile build files');
     subscribeWatcher(gulp.watch(['./src/**/*.spec.ts'], ['test']), 'Run tests');
   }
 }

--- a/docs/guides/CODING.md
+++ b/docs/guides/CODING.md
@@ -78,10 +78,7 @@ All code should be clear & well commented.
 
 ### Coding
 
-- All code styles are defined in the [tslint.json](https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/tslint.json) file. 
-
-  > **NOTE:** At the present time, all directives are authored using TypeScript. Contact the project owner(s) if you are going to write a directive in JavaScript so the appropriate linting can be setup in the project.
-
+- All code styles are defined in the [tslint.json](https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/tslint.json) file.
 - Ensure all code has valid style by running the gulp task `vet` to perform checks.
 - When fixing / enhancing existing code:
   - Do not reformat author's code.
@@ -95,7 +92,7 @@ All code should be clear & well commented.
 
 ## Documentation
 
-Directive documentation will be dynamically built at some point and therefore it is important all components are well documented. This process will use the Angular [dgeni](https://github.com/angular/dgeni) JavaScript documentation generator used by Angular, Protractor and other JavaScript projects. It is derived from [jsdoc](http://usejsdoc.org/). 
+Directive documentation will be dynamically built at some point and therefore it is important all components are well documented. This process will use the Angular [dgeni](https://github.com/angular/dgeni) JavaScript documentation generator used by Angular, Protractor and other JavaScript projects. It is derived from [jsdoc](http://usejsdoc.org/).
 
 - All non-trival functions should have a [jsdoc](http://usejsdoc.org/) description.
 - All Angular directives should have a comprehensive [jsdoc](http://usejsdoc.org/) block that explains the directive complete with the following:

--- a/docs/guides/GULP-TASKS.md
+++ b/docs/guides/GULP-TASKS.md
@@ -51,7 +51,7 @@ The most common one is `--verbose`. Depending on the task, this will usually out
 
 This task uses [webpack](http://webpack.github.io/) to transpile all TypeScript files and then create a webpack bundle.  
 
-By default, it creates a minified file with no comments or source maps. If the `--debug` argument is supplied, an un-minified bundle with an inline sourcemap is provided. These files are saved to the folder `/dist` as defined in `/build/config.ts`.
+By default, it creates a minified file with no comments or source maps. If the `--dev` argument is supplied, an un-minified bundle with an inline sourcemap is provided. These files are saved to the folder `/dist` as defined in `/build/config.ts`.
 
 The contents of the transpiled `/src/core/core.ts` is the first file added to the project.
 
@@ -60,10 +60,21 @@ All comments, including sourcemaps, are stripped from these generated library fi
 The version number for the file (and what's added in the comment banner within each file) is pulled dynamically from the `package.json` file in the repo. However the version can be manually set using the `--version` argument when running the task.
 
 ```bash
-$ gulp build-ts
-$ gulp build-ts --verbose
-$ gulp build-ts --verbose --version=1.2.3
+$ gulp build-lib
+$ gulp build-lib --verbose
+$ gulp build-lib --verbose --version=1.2.3
 ```
+### `gulp watch`
+
+If you want automatically run vet, test and build on file save, use this task.   
+
+By default, it setups watchers on typescript source files (`src/**/*.ts`), test files (`src/**/*.spec.ts`) and build files (`gulpfile.ts, build/**/*.ts`).  
+
+After saving a source file following workflow will be triggered: `source change -> vet -> transpile ts -> test ->  build library with webpack`. If any intermediate task will fail, then whole workflow will stop. That means you need to fix all vet and test errors in order to create `dist` package.   
+After saving a spec file workflow is the same expect the last step (build library with webpack) which is omitted.   
+After saving build file only typescript transpilation and vetting will be run.   
+
+`gulp watch` supports all common params which are used by other tasks (`debug`, `specs`, `verbose`, `version`, `dev`).  
 
 ### `gulp clean`
 


### PR DESCRIPTION
solves #49  
**TL;DR;**  
run `gulp watch --dev` to automatically generate development package (unminified, with comments and sourcemaps) on file change. 

**Full version:**  
`watch` task setup watchers for source files, spec files and build files.  
When source file changes following process will start:  
`source change -> vet -> transpile ts -> test -> build with webpack`  
Tasks run one after another and if any fails, whole chain will be broken. This achieved by adding dependencies to existing tasks (transpile depends on vet, test depends on transpile (you need source .js files for tests), build depends on test (if test is failed build is not valid)). This also means that for successful build you need to fix all vet and test errors.    

When spec changes following will start:  
`spec change -> vet -> transpile ts -> test`  
In this case build package won't be creted, because source files are not changed, so run test only.   

When build file changed, only transpilation process will start (source and specs are not changed).   

`watch` task supports all params supported by other tasks - `debug`, `specs`, `verbose`, `version`. Params will be passed to appropriate tasks, but  
**CHANGE**: for `build-lib` `debug` param renamed to `dev`, because when running with `gulp watch --debug` it also affects `test` task and produces very long output, which may be undesirable.  

Looking for feedback @ngOfficeUIFabric/ngofficeuifabric-members 
