### PR TITLE
Dropped jasmine-jquery from karma frameworks, added to files instead.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ coverage/
 # no js, just typescript
 *.js
 *.js.map
+
+!src/core/jquery.phantomjs.fix.js

--- a/config/karma.ts
+++ b/config/karma.ts
@@ -6,11 +6,11 @@ import * as webpackConfig from './webpack';
 
 /**
  * Karma configuration.
- * 
+ *
  * @function
  * @public
  * @see {link http://karma-runner.github.io/0.13/config/configuration-file.html}
- * 
+ *
  */
 module.exports = (config: karma.Config) => {
   // load webpack config settings
@@ -43,10 +43,13 @@ module.exports = (config: karma.Config) => {
     files: [
       'node_modules/angular/angular.js',
       'node_modules/angular-mocks/angular-mocks.js',
+      'node_modules/jquery/dist/jquery.min.js',
+      'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
+      'src/core/jquery.phantomjs.fix.js',
       'src/core/*.js',
       'src/components/*/*.js'
     ],
-    frameworks: ['jasmine-jquery', 'jasmine'],
+    frameworks: ['jasmine'],
     logLevel: config.LOG_WARN,
     plugins: ['karma-*'],
     port: 5793,
@@ -67,7 +70,7 @@ module.exports = (config: karma.Config) => {
 
 /**
  * Interface to define Karma coverage reporter configuration
- * 
+ *
  * @typedef karmaCoverageReporterConfigurationOptions
  * @property {string} type - Specify a reporter type (html | lcov | lcovonly | text | text-summary | cobertura | teamcity | json)
  * @property {string} dir - Output directory for coverage reports. If relative, resolved against karma.Configurationoptions.basePath.
@@ -81,7 +84,7 @@ interface IKarmaCoverageReporterConfigurationOptions {
 /**
  * Interface to extend the default Karma configuration options to add
  * stuff needed for code coverage & webpack.
- * 
+ *
  * @typedef karmaConfig
  * @augments karma.Config
  * @property {IKarmaCoverageReporterConfigurationOptions} coverageReporter - Settings for karma-coverage.

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -3,13 +3,13 @@
 This describes the guidelines developer should follow to run & create tests.
 
 - All code must have valid, **passing** unit tests
-- All code should have 100% test coverage or good reasons why it doesn't meet 100% coverage 
+- All code should have 100% test coverage or good reasons why it doesn't meet 100% coverage
 
 ## Testing Overview
 
 - [Jasmine](http://jasmine.github.io/) is used as the test framework for this project.
 - [Karma](http://karma-runner.github.io) is used as the test runner for all Angular unit tests.
-- [Protractor](https://angular.github.io/protractor/#/) is used for as the test runner for all Angular end-to-end (E2E) tests. 
+- [Protractor](https://angular.github.io/protractor/#/) is used for as the test runner for all Angular end-to-end (E2E) tests.
 
 Run all tests using the provided gulp task **test**:
 
@@ -17,7 +17,7 @@ Run all tests using the provided gulp task **test**:
 $ gulp test
 ```
 
-This includes two Karma reporters: 
+This includes two Karma reporters:
  - **progress**: This writes a summary of the test results & details for any failing tests.
  - **coverage**. This is used to create the code coverage reports with Istanbul.
 
@@ -28,6 +28,20 @@ $ gulp test --specs
 ```
 
 This will replace the **progress** reporter with the **spec** reporter and write each test & outcome to the console.
+
+## Using jQuery in tests
+We are not relying on jQuery in our library, that's why all elements in directives are wrapped in jqLite object and not jQuery. jqLite has limited functionality in comparison to jQuery and we made it possible to use jQuery and jasmine-jquery library in your specs.
+In Karma jQuery loaded after angular.js and is accessible from your code. For easier DOM manipulation and assertions you can wrap element in jQuery object manually:
+```javascript
+let $element = $compile('<your directive>')($scope);// <<---- $element is jqLite instance
+$element = jQuery($element[0]);// <<---- $element is jQuery instance
+```
+manipulate your jQuery object:
+```javascript
+let child = $element.find('div.child');// <<--- works with jQuery, not works with jqLite
+expect(child).toHaveClass('active');// <<---- jasmine-jquery assertion
+```
+**Note** on using mouse events with jQuery in your specs. For handling mouse events from jQuery object we included a special fix for PhantomJS browser, because it has an issue with raising this events. If you are experience a problem with raising event from jQuery object, you still can use native angular's jqLite event trigger, i.e. `$element.triggerHandler('click')`.
 
 ## Test Validation
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "istanbul": "^0.4.1",
     "istanbul-instrumenter-loader": "^0.1.3",
     "jasmine-core": "^2.4.1",
+    "jasmine-jquery": "^2.1.1",
+    "jquery": "^2.2.0",
     "karma": "^0.13.15",
     "karma-chrome-launcher": "^0.2.2",
     "karma-coverage": "^0.5.3",

--- a/src/core/jquery.phantomjs.fix.js
+++ b/src/core/jquery.phantomjs.fix.js
@@ -1,0 +1,19 @@
+jQuery.each(("blur focus focusin focusout click dblclick " +
+	"mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave").split(" "),
+	function(i, name) {
+
+	jQuery.fn[name] = function() {
+		var el = this[0];
+		var ev = document.createEvent('MouseEvent');
+        ev.initMouseEvent(
+            name,
+            true /* bubble */, true /* cancelable */,
+            window, null,
+            0, 0, 0, 0, /* coordinates */
+            false, false, false, false, /* modifier keys */
+            0 /*left*/, null
+        );
+        el.dispatchEvent(ev);
+	};
+} );
+


### PR DESCRIPTION
Solves #106 
What I'm thinking about is that we can go away from this "hack" with jQuery mouse events and use native angular's jqLite for events only, which works perfectly fine:  

``` javascript
it('should be able to click the dropdown', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
    let $scope: any = $rootScope.$new();
    let dropdown: JQuery = $compile('<uif-dropdown></uif-dropdown>')($scope);// jqLite actually
    let jqdropdown: JQuery = jQuery(dropdown[0]);//jquery
    $scope.$digest();

    dropdown.triggerHandler('click');// <<---  take a note on this line - jqLite

    $scope.$digest();
    let div: JQuery = jqdropdown.find('div.ms-Dropdown');

    expect(div).toHaveClass('is-open');

    dropdown.triggerHandler('click');

    $scope.$digest();
    expect(div).not.toHaveClass('is-open');
}));
```

Result: jqLite for event triggering, jQuery for DOM manipulation and convenient assertions, no hacks.  
Looks good?
