### PR TITLE
fix(callout): updated directive prop def

### DIFF
--- a/src/components/callout/calloutDirective.spec.ts
+++ b/src/components/callout/calloutDirective.spec.ts
@@ -25,6 +25,19 @@ describe('calloutDirectives:', () => {
       expect(calloutElement[0].tagName === 'DIV').toBeTruthy();
     });
 
+    it('should not throw error on mouseenter and leave', () => {
+
+      element.triggerHandler('mouseenter');
+      scope.$digest();
+
+      expect(() => {
+        element.triggerHandler('mouseleave');
+      }).not.toThrow(new Error('[$compile:nonassign] Expression \'undefined\' ' +
+      'used with directive \'uifCallout\' is non-assignable!\n' +
+      'http://errors.angularjs.org/1.4.9/$compile/nonassign?p0=undefined&p1=uifCallout'));
+
+    });
+
     it('main element should have callout CSS class', () => {
       let calloutElement: JQuery = element.find('div').first();
 

--- a/src/components/callout/calloutDirective.ts
+++ b/src/components/callout/calloutDirective.ts
@@ -195,7 +195,7 @@ export class CalloutDirective implements ng.IDirective {
   public require: string[] = ['uifCallout'];
 
   public scope: any = {
-    ngShow: '=',
+    ngShow: '=?',
     uifType: '@'
   };
 


### PR DESCRIPTION
An update to Angular 1.4.9 introduced a regression in ngOfficeUiFabric as explained in #139. This fixes the issue for the `uif-callout` directive.
