### PR TITLE
fix(searchbox): update directive prop def

### DIFF
--- a/src/components/searchbox/searchboxDirective.ts
+++ b/src/components/searchbox/searchboxDirective.ts
@@ -52,8 +52,8 @@ export class SearchBoxDirective implements ng.IDirective {
 
 
   public scope: any = {
-    placeholder: '=',
-    value: '='
+    placeholder: '=?',
+    value: '=?'
   };
 
   public static factory(): ng.IDirectiveFactory {


### PR DESCRIPTION
An update to Angular 1.4.9 introduced a regression in ngOfficeUiFabric as explained in #139. This fixes the issue for the `uif-searchbox` directive.

References #139.
