### PR TITLE
fix(spinner): Invalid closing tag in spinner documentation

### DIFF
--- a/src/components/spinner/demo/index.html
+++ b/src/components/spinner/demo/index.html
@@ -22,7 +22,7 @@
   <p>To render spinner, use the following markup:
     <br />
     <code>
-      &lt;uif-spinner&gt;&lt;uif-spinner/&gt;
+      &lt;uif-spinner&gt;&lt;/uif-spinner&gt;
     </code>
   </p>
 
@@ -35,7 +35,7 @@
   <p>By default, small spinner is rendered. Above is shorthand of:
     <br />
     <code>
-      &lt;uif-spinner uif-size="small"&gt;&lt;uif-spinner/&gt;
+      &lt;uif-spinner uif-size="small"&gt;&lt;/uif-spinner&gt;
     </code>
   </p>
 
@@ -48,7 +48,7 @@
   <p>To render large spinner, use the following markup:
     <br />
     <code>
-      &lt;uif-spinner uif-size="large"&gt;&lt;uif-spinner/&gt;
+      &lt;uif-spinner uif-size="large"&gt;&lt;/uif-spinner&gt;
     </code>
   </p>
 
@@ -61,7 +61,7 @@
   <p>You can also add content to the spinner, which will become it's label :
     <br />
     <code>
-      &lt;uif-spinner uif-size="large"&gt;Loading...&lt;uif-spinner/&gt;
+      &lt;uif-spinner uif-size="large"&gt;Loading...&lt;/uif-spinner&gt;
     </code>
   </p>
 
@@ -74,7 +74,7 @@
   <p>You can control visibility of the spinner with <code>ngShow</code> directive
     <br />
     <code>
-      &lt;uif-spinner uif-size="large" ng-show="spinnerVisible"&gt;&lt;uif-spinner/&gt;
+      &lt;uif-spinner uif-size="large" ng-show="spinnerVisible"&gt;&lt;/uif-spinner&gt;
     </code>
   </p>
 


### PR DESCRIPTION
On the spinner demo page all examples are now `</uif-spinner>` rather than `<uif-spinner/>`.

closes #150
