### PR TITLE
Fixing issue with memory leaks.

### DIFF
--- a/build/global.d.ts
+++ b/build/global.d.ts
@@ -37,4 +37,5 @@ interface ICommandLineArgs {
   dev?: boolean;
   watch?: boolean;
   serve?: boolean;
+  file?: string;
 }

--- a/build/gulp/tasks/live-dev.ts
+++ b/build/gulp/tasks/live-dev.ts
@@ -86,10 +86,13 @@ export class GulpTask extends BaseGulpTask {
       let isWindows: boolean = (process.platform.lastIndexOf('win') === 0);
 
       let command: string = isWindows ? 'cmd.exe' : 'sh';
-      let args: string[]  = isWindows ? ['/c', 'gulp ' + task].concat(process.argv.slice(3)).concat(additionalArgs)
-                                      : ['-c', 'gulp ' + task].concat(process.argv.slice(3)).concat(additionalArgs);
+      let args: string  = ['gulp ' + task].concat(process.argv.slice(3)).concat(additionalArgs).join(' ');
 
-      return childProcess.spawn(command, args, { env: process.env , stdio: 'inherit' });
+      if (isWindows) {
+        return childProcess.spawn(command, ['/c', args], { env: process.env , stdio: 'inherit' });
+      }
+
+      return childProcess.spawn(command, ['-c', args], { env: process.env , stdio: 'inherit' });
     };
 
     let modeName: string = 'DEV';

--- a/build/gulp/tasks/test.ts
+++ b/build/gulp/tasks/test.ts
@@ -5,6 +5,7 @@ import {Utils} from '../utils';
 import * as yargs from 'yargs';
 import * as karma from 'karma';
 import * as gulp from 'gulp';
+import * as path from 'path';
 
 /**
  * Runs all tests against the directives.
@@ -70,6 +71,28 @@ export class GulpTask extends BaseGulpTask {
       karmaConfig.singleRun = false;
       karmaConfig.browsers = ['Chrome', 'PhantomJS'];
     }
+
+    if (this._args.file) {
+      let currentPath: path.ParsedPath = path.parse(this._args.file);
+      let allExceptSpecs: string = path.join(currentPath.dir, '!(*.spec).js');
+      let allSpecs: string = path.join(currentPath.dir, '*.spec.js');
+      let pathParts: string[] = currentPath.dir.split(path.sep);
+      let dirName: string = pathParts[pathParts.length - 1] || pathParts[pathParts.length - 2];
+
+      karmaConfig.files = [
+          'node_modules/angular/angular.js',
+          'node_modules/angular-mocks/angular-mocks.js',
+          'node_modules/jquery/dist/jquery.min.js',
+          'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
+          'src/core/jquery.phantomjs.fix.js',
+          'src/core/*.js',
+          allExceptSpecs,
+          allSpecs
+        ];
+
+      Utils.log(`Using specs under src/components/${dirName}/`);
+    }
+
 
     // create karma server
     let karmaServer: karma.Server = new karma.Server(karmaConfig, (karmaResult: number) => {


### PR DESCRIPTION
For `live-dev` tasks `test` and `build-lib` offloaded into separate node.js process which is closed immediately after finishing. This prevents memory leaks.  
After running ~30 times build and test, memory consumption is about 800-900MB and no more.  
Consider: this works on windows cause I'm on windows. Fix should also work for *nix and osx, but I don't have *nix or osx installed, so unable to test properly.     

**UPD:** verified on linux (ubuntu) - found one issue and fixed. On linux all good. Still not sure how it looks like on osx....  

**UPD2:** verified on osx (el capitan) - looks good.

Solves #160
