### PR TITLE
fix(icon): remove icons not supported by fabric

### DIFF
--- a/src/components/icon/iconEnum.ts
+++ b/src/components/icon/iconEnum.ts
@@ -236,7 +236,6 @@ export enum IconEnum {
   noteForward,
   noteReply,
   notRecurring,
-  onedrive,
   onlineAdd,
   onlineJoin,
   oofReply,


### PR DESCRIPTION
Office UI Fabric 2.x release removed a few icons that are no longer supported. This change updates the icon enum to reflect the current supported icons.

Closes #169.
