### PR TITLE
refactor(): move dupe test file ref to config

### DIFF
--- a/build/gulp/tasks/test.ts
+++ b/build/gulp/tasks/test.ts
@@ -2,6 +2,7 @@
 
 import {BaseGulpTask} from '../BaseGulpTask';
 import {Utils} from '../utils';
+import {BuildConfig} from '../../../config/build';
 import * as yargs from 'yargs';
 import * as karma from 'karma';
 import * as gulp from 'gulp';
@@ -33,10 +34,10 @@ export class GulpTask extends BaseGulpTask {
    * @property  {Object}  options   - Any command line flags that can be passed to the task.
    */
   public static options: any = {
-    'debug':   'Set karma log level to DEBUG',
-    'specs':   'Output all tests being run',
+    'debug': 'Set karma log level to DEBUG',
+    'specs': 'Output all tests being run',
     'verbose': 'Output all TypeScript files being built & set karma log level to INFO',
-    'watch':   'Adds Chrome browser and start listening on file changes for easier debugging'
+    'watch': 'Adds Chrome browser and start listening on file changes for easier debugging'
   };
 
   /**
@@ -79,16 +80,9 @@ export class GulpTask extends BaseGulpTask {
       let pathParts: string[] = currentPath.dir.split(path.sep);
       let dirName: string = pathParts[pathParts.length - 1] || pathParts[pathParts.length - 2];
 
-      karmaConfig.files = [
-          'node_modules/angular/angular.js',
-          'node_modules/angular-mocks/angular-mocks.js',
-          'node_modules/jquery/dist/jquery.min.js',
-          'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
-          'src/core/jquery.phantomjs.fix.js',
-          'src/core/*.js',
-          allExceptSpecs,
-          allSpecs
-        ];
+      karmaConfig.files = BuildConfig.CORE_TEST_FILES.concat(
+        allExceptSpecs, allSpecs
+      );
 
       Utils.log(`Using specs under src/components/${dirName}/`);
     }

--- a/config/build.ts
+++ b/config/build.ts
@@ -72,4 +72,23 @@ export class BuildConfig {
   public static ALL_TYPESCRIPT: string[] = BuildConfig.BUILD_TYPESCRIPT
     .concat(BuildConfig.LIB_TYPESCRIPT)
     .concat(BuildConfig.LIB_TEST_TYPESCRIPT);
+
+  /**
+   * All core files used in testing.
+   */
+  public static CORE_TEST_FILES: string[] = [
+    BuildConfig.NODE_MODULES + '/angular/angular.js',
+    BuildConfig.NODE_MODULES + '/angular-mocks/angular-mocks.js',
+    BuildConfig.NODE_MODULES + '/jquery/dist/jquery.min.js',
+    BuildConfig.NODE_MODULES + '/jasmine-jquery/lib/jasmine-jquery.js',
+    'src/core/jquery.phantomjs.fix.js',
+    'src/core/*.js'
+  ];
+  /**
+   * ALl test files.
+   */
+  public static ALL_SPEC_FILES: string[] = [
+    'src/components/*/!(*.spec).js',
+    'src/components/*/*.spec.js'
+  ];
 }

--- a/config/karma.ts
+++ b/config/karma.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import {BuildConfig} from './build';
 import * as karma from 'karma';
 import * as webpack from 'webpack';
 import * as webpackConfig from './webpack';
@@ -35,16 +36,9 @@ module.exports = (config: karma.Config) => {
       dir: 'coverage/',
       type: 'lcov'
     },
-    files: [
-      'node_modules/angular/angular.js',
-      'node_modules/angular-mocks/angular-mocks.js',
-      'node_modules/jquery/dist/jquery.min.js',
-      'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
-      'src/core/jquery.phantomjs.fix.js',
-      'src/core/*.js',
-      'src/components/*/!(*.spec).js',
-      'src/components/*/*.spec.js'
-    ],
+    files: BuildConfig.CORE_TEST_FILES.concat(
+      BuildConfig.ALL_SPEC_FILES
+    ),
     frameworks: ['jasmine'],
     logLevel: config.LOG_WARN,
     plugins: ['karma-*'],


### PR DESCRIPTION
Refactored duplicate test file references to centralized build config.

Closes #157.
