### PR TITLE
feat(button): add button directive

### DIFF
--- a/npm-debug.log.f82957eb17358941b8a37dfce7b03a64
+++ b/npm-debug.log.f82957eb17358941b8a37dfce7b03a64
@@ -1,0 +1,25 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/Users/ac/.nvm/versions/node/v5.4.1/bin/node',
+1 verbose cli   '/Users/ac/.nvm/versions/node/v5.4.1/bin/npm',
+1 verbose cli   'config',
+1 verbose cli   'get',
+1 verbose cli   'prefix' ]
+2 info using npm@3.3.12
+3 info using node@v5.4.1
+4 verbose exit [ 0, true ]
+5 verbose stack Error: write EPIPE
+5 verbose stack     at Object.exports._errnoException (util.js:856:11)
+5 verbose stack     at exports._exceptionWithHostPort (util.js:879:20)
+5 verbose stack     at WriteWrap.afterWrite (net.js:763:14)
+6 verbose cwd /Users/ac/repos/ac-ng-officeuifabric
+7 error Darwin 15.3.0
+8 error argv "/Users/ac/.nvm/versions/node/v5.4.1/bin/node" "/Users/ac/.nvm/versions/node/v5.4.1/bin/npm" "config" "get" "prefix"
+9 error node v5.4.1
+10 error npm  v3.3.12
+11 error code EPIPE
+12 error errno EPIPE
+13 error syscall write
+14 error write EPIPE
+15 error If you need help, you may report this error at:
+15 error     <https://github.com/npm/npm/issues>
+16 verbose exit [ 1, true ]

--- a/src/components/button/.gitignore
+++ b/src/components/button/.gitignore
@@ -1,0 +1,1 @@
+!demo/index.js

--- a/src/components/button/buttonDirective.spec.ts
+++ b/src/components/button/buttonDirective.spec.ts
@@ -1,0 +1,857 @@
+'use strict';
+
+import * as ng from 'angular';
+import {ButtonTypeEnum} from './buttonTypeEnum';
+
+describe('buttonDirective: <uif-button />', () => {
+
+  /**
+   * before each test load all required modules
+   */
+  beforeEach(() => {
+    angular.mock.module('officeuifabric.core');
+    angular.mock.module('officeuifabric.components.icon');
+    angular.mock.module('officeuifabric.components.button');
+  });
+
+  /**
+   * tests for the description directive used in the button
+   */
+  describe('buttonDescriptionDirective: <uif-button-description />', () => {
+    let element: JQuery;
+    let scope: ng.IScope;
+
+    beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: Function) => {
+      let html: string = '<uif-button-description>Lorem Ipsum</uif-button>';
+      scope = $rootScope;
+
+      element = $compile(html)(scope);  // jqLite object
+      element = jQuery(element[0]);     // jQuery object
+
+      scope.$digest();
+    }));
+
+    it('should create correct HTML', () => {
+      // expected rendered HTML:
+      // <span class="ms-Button-description">Some description goes here of the button</span>
+
+      // verify expected HTML tag
+      expect(element.prop('tagName')).toEqual('SPAN');
+    });
+
+    it('should set correct Office UI Fabric CSS class', () => {
+      // expected rendered HTML:
+      // <span class="ms-Button-description">Some description goes here of the button</span>
+
+      // check expected CSS classes
+      expect(element).toHaveClass('ms-Button-description');
+    });
+
+    // the value specified should render within the body of the rendered element
+    it('should be able to set the description', () => {
+      // expected rendered HTML:
+      // <span class="ms-Button-description">Lorem Ipsum</span>
+
+      // check value of the span
+      let spanElement: JQuery = element.find('span');
+      expect(spanElement[0].innerText).toBe('Lorem Ipsum');
+    });
+  });
+
+
+
+
+  /**
+   * tests when the button should be rendered as a <button> tag
+   */
+  describe('rendered as <button>', () => {
+    let element: JQuery;
+    let scope: ng.IScope;
+
+    beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: Function) => {
+      let html: string = '<uif-button>Lorem Ipsum</uif-button>';
+      scope = $rootScope;
+
+      element = $compile(html)(scope);    // jqLite object
+      element = jQuery(element[0]);       // jQuery object
+
+      scope.$digest();
+    }));
+
+    it('should create correct HTML', () => {
+      // expected rendered HTML:
+      // <button class="ms-Button">
+      //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+      // </button>
+
+      // verify expected HTML tag
+      expect(element.prop('tagName')).toEqual('BUTTON');
+
+      // check child
+      let spanElement: JQuery = element.find('span');
+      expect(spanElement.prop('tagName')).toEqual('SPAN');
+    });
+
+    it('should set correct Office UI Fabric CSS class', () => {
+      // expected rendered HTML:
+      // <button class="ms-Button">
+      //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+      // </button>
+
+      // verify button CSS
+      expect(element[0]).toHaveClass('ms-Button');
+
+      // verify inner span CSS
+      let spanElement: JQuery = element.find('span');
+      expect(spanElement[0]).toHaveClass('ms-Button-label');
+    });
+
+    // should not throw an error when null button type enum passed in
+    it('should not log error on null button types', inject(($log: ng.ILogService, $compile: Function) => {
+      // create button with no attributes
+      let html: string = '<uif-button>Lorem Ipsum</uif-button>';
+      $compile(html)(scope);
+      scope.$digest();
+
+      // verify no errors logged
+      expect($log.error.logs.length).toBe(0);
+    }));
+
+    // should not throw an error when valid button type enum passed in
+    it('should not log error on valid button types', inject(($log: ng.ILogService, $compile: Function) => {
+      let html: string = '';
+
+      // create buttons for each enum option
+      Object.keys(ButtonTypeEnum)
+        .forEach((buttonType: string) => {
+          html = '<uif-button uif-type="' + buttonType + '">Lorem Ipsum</uif-button>';
+          $compile(html)(scope);
+          scope.$digest();
+
+          // verify no errors logged
+          expect($log.error.logs.length).toBe(0);
+        });
+    }));
+
+    // should log an error when invalid button type passed specified
+    it('should log error on invalid button types', inject(($log: ng.ILogService, $compile: Function) => {
+      // check no error when no type specified
+      let html: string = '<uif-button uif-type="INVALID">Lorem Ipsum</uif-button>';
+      $compile(html)(scope);
+      scope.$digest();
+
+      // verify error logged
+      expect($log.error.logs.length).toBe(1);
+    }));
+
+    // the value specified should render within the body of the rendered element
+    it('should be able to set the label', () => {
+      // expected rendered HTML:
+      // <button class="ms-Button">
+      //   <span class="ms-Button-label">Lorem Ipsum</span>
+      // </button>
+
+      // check value of the span
+      let spanElement: JQuery = element.find('span');
+      expect(spanElement[0].innerText).toBe('Lorem Ipsum');
+    });
+
+    // the rendered element should render enabled by default
+    it('should be able to set enabled', () => {
+      // expected rendered HTML:
+      // <button class="ms-Button">
+      //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+      // </button>
+
+      // verify no disabled class present
+      expect(element).not.toHaveClass('is-disabled');
+    });
+
+    // if set to disabled, this should render on the button rendered element
+    it('should be able to set disabled', inject(($compile: Function) => {
+      // expected rendered HTML:
+      // <button class="ms-Button is-disabled">
+      //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+      // </button>
+
+      let html: string = '<uif-button disabled>Lorem Ipsum</uif-button>';
+      let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+      buttonElement = jQuery(buttonElement[0]);           // jQuery object
+      scope.$digest();
+
+      // verify no disabled class present
+      expect(buttonElement[0]).toHaveClass('is-disabled');
+    }));
+
+    /**
+     * action (default) button tests
+     */
+    describe('action (default) button', () => {
+      // the rendered button should not have any button type decorator classes
+      it('should not have any button decorator classes', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </button>
+
+        let html: string = '<uif-button>Lorem Ipsum</uif-button>';
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify no decorator classes rendered by the directive
+        expect(buttonElement).not.toHaveClass('ms-Button--primary');
+        expect(buttonElement).not.toHaveClass('ms-Button--command');
+        expect(buttonElement).not.toHaveClass('ms-Button--compound');
+        expect(buttonElement).not.toHaveClass('ms-Button--hero');
+      }));
+
+      // the icon specified should not be rendered (action doesn't support icon)
+      it('should not be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </button>
+
+        let html: string = `<uif-button>
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify no wrapper was created
+        expect(buttonElement.find('span.ms-Button-icon').length).toBe(0);
+        // verify no icon was added
+        expect(buttonElement.find('uif-icon').length).toBe(0);
+      }));
+    }); // describe('action (default) button')
+
+    describe('primary button', () => {
+      // ensure that the button has the correct CSS class for the button type
+      it('should include correct CSS class', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--primary">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </button>
+
+        let html: string = '<uif-button uif-type="primary">Lorem Ipsum</uif-button>';
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify correct decorator class
+        expect(buttonElement).toHaveClass('ms-Button--primary');
+      }));
+
+      // the icon specified should not be rendered (primary doesn't support icon)
+      it('should not be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--primary">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </button>
+
+        let html: string = `<uif-button uif-type="primary">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify no wrapper was created
+        expect(buttonElement.find('span.ms-Button-icon').length).toBe(0);
+        // verify no icon was added
+        expect(buttonElement.find('uif-icon').length).toBe(0);
+      }));
+
+      // the icon specified should not be rendered (primary doesn't support icon)
+      it('should log error when icon specified', inject(($log: ng.ILogService, $compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--primary">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </button>
+
+        let html: string = `<uif-button uif-type="primary">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        $compile(html)(scope);
+        scope.$digest();
+
+        // verify error logged
+        expect($log.error.logs.length).toBe(1);
+      }));
+    }); // describe('primary button')
+
+    /**
+     * command button tests
+     */
+    describe('command button', () => {
+      // ensure that the button has the correct CSS class for the button type
+      it('should include correct CSS class', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--command">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </button>
+
+        let html: string = '<uif-button uif-type="command">Lorem Ipsum</uif-button>';
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify no icon was rendered by the directive
+        expect(buttonElement).toHaveClass('ms-Button--command');
+      }));
+
+      // the icon specified should render within the body of the rendered element
+      it('should be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--command">
+        //   <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
+        //   <span class="ms-Button-label">+ Button as &lt;button&gt;</span>
+        // </button>
+        // >>> REALLY should render
+        // <button class="ms-Button ms-Button--command">
+        //   <span class="ms-Button-icon"><uif-icon uif-type="plus"></uif-icon></span>
+        //   <span class="ms-Button-label">Hero Button</span>
+        // </button>
+
+        let html: string = `<uif-button uif-type="command">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify class on inner label
+        expect(buttonElement.children('span.ms-Button-label').length).toBe(1);
+        // verify icon was rendered by the directive
+        expect(buttonElement.children('span.ms-Button-icon').length).toBe(1);
+      }));
+
+      it('should not log error when icon specified', inject(($log: ng.ILogService, $compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--command">
+        //   <span class="ms-Button-icon"><uif-icon uif-type="plus"></uif-icon></span>
+        //   <span class="ms-Button-label">Hero Button</span>
+        // </button>
+
+        let html: string = `<uif-button uif-type="command">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        $compile(html)(scope);
+        scope.$digest();
+
+        // verify error logged
+        expect($log.error.logs.length).toBe(0);
+      }));
+    }); // describe('command button')
+
+    /**
+     * compound button tests
+     */
+    describe('compound button', () => {
+      // ensure that the button has the correct CSS class for the button type
+      it('should include correct CSS class (label only)', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--compound">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </button>
+
+        let html: string = '<uif-button uif-type="compound">Lorem Ipsum</uif-button>';
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify class on button element
+        expect(buttonElement).toHaveClass('ms-Button--compound');
+        // verify class on inner label
+        expect(buttonElement.children('span.ms-Button-label').length).toBe(1);
+      }));
+
+      it('should include correct CSS class (label & description only)', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--compound">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        //   <span class="ms-Button-description">Button description</span>
+        // </button>
+
+        let html: string = `<uif-button uif-type="compound">
+                              Lorem Ipsum
+                              <uif-button-description>Button Description</uif-button-description>
+                            </uif-button>`;
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify class on button element
+        expect(buttonElement).toHaveClass('ms-Button--compound');
+        // verify class on inner label
+        expect(buttonElement.children('span.ms-Button-label').length).toBe(1);
+        // verify class on inner description
+        expect(buttonElement.children('span.ms-Button-description').length).toBe(1);
+      }));
+
+      // the icon specified should not be rendered (compound doesn't support icon)
+      it('should not be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--compound">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        //   <span class="ms-Button-description">Some description goes here of the button</span>
+        // </button>
+
+        let html: string = `<uif-button uif-type="compound">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify no icon was rendered by the directive
+        expect(buttonElement.children('span.ms-Button-icon').length).toBe(0);
+        expect(buttonElement.find('uif-icon').length).toBe(0);
+      }));
+    }); // describe('compound button')
+
+    /**
+     * hero button tests
+     */
+    describe('hero button', () => {
+      // ensure that the button has the correct CSS class for the button type
+      it('should include correct CSS class', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--hero">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </button>
+
+        let html: string = '<uif-button uif-type="hero">Lorem Ipsum</uif-button>';
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify no icon was rendered by the directive
+        expect(buttonElement).toHaveClass('ms-Button--hero');
+      }));
+
+      // the icon specified should render within the body of the rendered element
+      it('should be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--hero">
+        //   <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
+        //   <span class="ms-Button-label">Hero Button</span>
+        // </button>
+        // >>> REALLY should render
+        // <button class="ms-Button ms-Button--hero">
+        //   <span class="ms-Button-icon"><uif-icon uif-type="plus"></uif-icon></span>
+        //   <span class="ms-Button-label">Hero Button</span>
+        // </button>
+
+        let html: string = `<uif-button uif-type="hero">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let buttonElement: JQuery = $compile(html)(scope);  // jqLite object
+        buttonElement = jQuery(buttonElement[0]);           // jQuery object
+
+        // verify class on inner label
+        expect(buttonElement.children('span.ms-Button-label').length).toBe(1);
+        // verify icon was rendered by the directive
+        expect(buttonElement.children('span.ms-Button-icon').length).toBe(1);
+      }));
+    }); // describe('hero button')
+
+  }); // describe('rendered as <button>')
+
+
+
+
+
+
+
+
+
+
+  /**
+   * tests when the button should be rendered as an <a> tag
+   */
+  describe('rendered as <a>', () => {
+    let element: JQuery;
+    let scope: ng.IScope;
+
+    beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: Function) => {
+      let html: string = '<uif-button ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>';
+      scope = $rootScope;
+
+      // element = jqLite object
+      element = $compile(html)(scope);
+      // element = jQuery object
+      element = jQuery(element[0]);
+
+      scope.$digest();
+    }));
+
+    it('should create HTML <a> tag', () => {
+      // expected rendered HTML:
+      // <a class="ms-Button">
+      //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+      // </a>
+
+      // verify expected HTML tag
+      expect(element.prop('tagName')).toEqual('A');
+
+      // check child
+      let spanElement: JQuery = element.find('span');
+      expect(spanElement.prop('tagName')).toEqual('SPAN');
+    });
+
+    it('should set correct Office UI Fabric CSS class', () => {
+      // expected rendered HTML:
+      // <a class="ms-Button">
+      //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+      // </a>
+
+      // verify button CSS
+      expect(element[0]).toHaveClass('ms-Button');
+
+      // check child
+      let spanElement: JQuery = element.find('span');
+      expect(spanElement.prop('tagName')).toEqual('SPAN');
+    });
+
+    // should not throw an error when valid button type enum passed in
+    it('should not log error on null button types', inject(($log: ng.ILogService, $compile: Function) => {
+      // check no error when no type specified
+      let html: string = '<uif-button ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>';
+      $compile(html)(scope);
+      scope.$digest();
+
+      expect($log.error.logs.length).toBe(0);
+    }));
+
+    // should not throw an error when valid button type enum passed in
+    it('should not log error on valid button types', inject(($log: ng.ILogService, $compile: Function) => {
+      let html: string = '';
+      // for all enum options...
+      // check no error when no type specified
+      Object.keys(ButtonTypeEnum)
+        .forEach((buttonType: string) => {
+          html = '<uif-button uif-type="' + buttonType + '" ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>';
+          $compile(html)(scope);
+          scope.$digest();
+
+          // verify no errors logged
+          expect($log.error.logs.length).toBe(0);
+        });
+    }));
+
+    // should throw an error when invalid button type passed in
+    it('should log error on invalid button types', inject(($log: ng.ILogService, $compile: Function) => {
+      // check no error when no type specified
+      let html: string = '<uif-button uif-type="INVALID" ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>';
+      $compile(html)(scope);
+      scope.$digest();
+
+      // verify error logged
+      expect($log.error.logs.length).toBe(1);
+    }));
+
+    // the value specified should render within the body of the rendered element
+    it('should be able to set the label', () => {
+      // expected rendered HTML:
+      // <a class="ms-Button">
+      //   <span class="ms-Button-label">Button as &lt;a&gt;</span>
+      // </a>
+
+      // check value of the span
+      let spanElement: JQuery = element.find('span');
+      expect(spanElement[0].innerText).toBe('Lorem Ipsum');
+    });
+
+    // the rendered element should render enabled by default
+    it('should be able to set enabled', () => {
+      // expected rendered HTML:
+      // <a class="ms-Button">
+      //   <span class="ms-Button-label">Button as &lt;a&gt;</span>
+      // </a>
+
+      // verify no disabled class present
+      expect(element).not.toHaveClass('is-disabled');
+    });
+
+    // if set to disabled, this should render on the button rendered element
+    it('should be able to set disabled', inject(($compile: Function) => {
+      // expected rendered HTML:
+      // <a class="ms-Button is-disabled">
+      //   <span class="ms-Button-label">Button as &lt;a&gt;</span>
+      // </a>
+
+      let html: string = '<uif-button disabled ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>';
+      let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+      linkElement = jQuery(linkElement[0]);             // jQuery object
+      scope.$digest();
+
+      // verify no disabled class present
+      expect(linkElement[0]).toHaveClass('is-disabled');
+    }));
+
+    /**
+     * action (default) button tests
+     */
+    describe('action (default) button', () => {
+      // the rendered button should not have any button type decorator classes
+      it('should not have any button decorator classes', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </a>
+
+        let html: string = '<uif-button ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>';
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify no decorator classes rendered by the directive
+        expect(linkElement).not.toHaveClass('ms-Button--primary');
+        expect(linkElement).not.toHaveClass('ms-Button--command');
+        expect(linkElement).not.toHaveClass('ms-Button--compound');
+        expect(linkElement).not.toHaveClass('ms-Button--hero');
+      }));
+
+      // the icon specified should not be rendered (action doesn't support icon)
+      it('should not be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button">
+        //   <span class="ms-Button-label">Button as &lt;a&gt;</span>
+        // </a>
+
+        let html: string = `<uif-button ng-href="http://ngOfficeUiFabric.com">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify no wrapper was created
+        expect(linkElement.find('span.ms-Button-icon').length).toBe(0);
+        // verify no icon was added
+        expect(linkElement.find('uif-icon').length).toBe(0);
+      }));
+
+    }); // describe('action (default) button')
+
+    /**
+     * primary button tests
+     */
+    describe('primary button', () => {
+      // ensure that the button has the correct CSS class for the button type
+      it('should include correct CSS class', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--primary">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </a>
+
+        let html: string = '<uif-button uif-type="primary" ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>';
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify correct decorator class
+        expect(linkElement).toHaveClass('ms-Button--primary');
+      }));
+
+      // the icon specified should not be rendered (primary doesn't support icon)
+      it('should not be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--primary">
+        //   <span class="ms-Button-label">Button as &lt;a&gt;</span>
+        // </a>
+
+        let html: string = `<uif-button uif-type="primary" ng-href="http://ngOfficeUiFabric.com">'
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify no wrapper was created
+        expect(linkElement.find('span.ms-Button-icon').length).toBe(0);
+        // verify no icon was added
+        expect(linkElement.find('uif-icon').length).toBe(0);
+      }));
+
+      // the icon specified should not be rendered (primary doesn't support icon)
+      it('should log error when icon specified', inject(($log: ng.ILogService, $compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--primary">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </a>
+
+        let html: string = `<uif-button uif-type="primary" ng-href="http://ngOfficeUiFabric.com">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        $compile(html)(scope);
+        scope.$digest();
+
+        // verify error logged
+        expect($log.error.logs.length).toBe(1);
+      }));
+    }); // describe('primary button')
+
+    describe('command button', () => {
+      // ensure that the button has the correct CSS class for the button type
+      it('should include correct CSS class', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--command">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </a>
+
+        let html: string = '<uif-button uif-type="command">Lorem Ipsum</uif-button>';
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify no icon was rendered by the directive
+        expect(linkElement).toHaveClass('ms-Button--command');
+      }));
+
+      // the icon specified should render within the body of the rendered element
+      it('should be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--command">
+        //   <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
+        //   <span class="ms-Button-label">+ Button as &lt;a&gt;</span>
+        // </a>
+        // >>> REALLY should render
+        // <a class="ms-Button ms-Button--command">
+        //   <span class="ms-Button-icon"><uif-icon uif-type="plus"></uif-icon></span>
+        //   <span class="ms-Button-label">+ Button as &lt;a&gt;</span>
+        // </a>
+
+        let html: string = `<uif-button uif-type="command" ng-href="http://ngOfficeUiFabric.com">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify class on inner label
+        expect(linkElement.children('span.ms-Button-label').length).toBe(1);
+        // verify icon was rendered by the directive
+        expect(linkElement.children('span.ms-Button-icon').length).toBe(1);
+      }));
+
+      it('should not log error when icon specified', inject(($log: ng.ILogService, $compile: Function) => {
+        // expected rendered HTML:
+        // <button class="ms-Button ms-Button--command">
+        //   <span class="ms-Button-icon"><uif-icon uif-type="plus"></uif-icon></span>
+        //   <span class="ms-Button-label">Hero Button</span>
+        // </button>
+
+        let html: string = `<uif-button uif-type="command" ng-href="http://ngOfficeUiFabric.com">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        $compile(html)(scope);
+        scope.$digest();
+
+        // verify error logged
+        expect($log.error.logs.length).toBe(0);
+      }));
+    }); // describe('command button')
+
+    /**
+     * compound button tests
+     */
+    describe('compound button', () => {
+      // ensure that the button has the correct CSS class for the button type
+      it('should include correct CSS class (label only)', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--compound">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </a>
+
+        let html: string = `<uif-button uif-type="compound" ng-href="http://ngOfficeUiFabric.com">
+                              Lorem Ipsum
+                            </uif-button>`;
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify no icon was rendered by the directive
+        expect(linkElement).toHaveClass('ms-Button--compound');
+        // verify class on inner label
+        expect(linkElement.children('span.ms-Button-label').length).toBe(1);
+      }));
+
+      it('should include correct CSS class (label & description only)', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--compound">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        //   <span class="ms-Button-description">Button description</span>
+        // </a>
+
+        let html: string = `<uif-button uif-type="compound" ng-href="http://ngOfficeUiFabric.com">
+                              Lorem Ipsum
+                              <uif-button-description>Button Description</uif-button-description>
+                            </uif-button>`;
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);           // jQuery object
+
+        // verify class on button element
+        expect(linkElement).toHaveClass('ms-Button--compound');
+        // verify class on inner label
+        expect(linkElement.children('span.ms-Button-label').length).toBe(1);
+        // verify class on inner description
+        expect(linkElement.children('span.ms-Button-description').length).toBe(1);
+      }));
+
+      // the icon specified should not be rendered (compound doesn't support icon)
+      it('should not be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--compound">
+        //   <span class="ms-Button-label">Button as &lt;a&gt;</span>
+        //   <span class="ms-Button-description">Some description goes here of the button</span>
+        // </a>
+
+        let html: string = `<uif-button ng-href="http://ngOfficeUiFabric.com">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify no icon was rendered by the directive
+        expect(linkElement.children('span.ms-Button-icon').length).toBe(0);
+        expect(linkElement.find('uif-icon').length).toBe(0);
+      }));
+    }); // describe('compound button')
+
+    /**
+     * hero button tests
+     */
+    describe('hero button', () => {
+      // ensure that the button has the correct CSS class for the button type
+      it('should include correct CSS class', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--hero">
+        //   <span class="ms-Button-label">Button as &lt;button&gt;</span>
+        // </a>
+
+        let html: string = `<uif-button uif-type="hero" ng-href="http://ngOfficeUiFabric.com">
+                              Lorem Ipsum
+                            </uif-button>`;
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify no icon was rendered by the directive
+        expect(linkElement).toHaveClass('ms-Button--hero');
+      }));
+
+      // the icon specified should render within the body of the rendered element
+      it('should be able to set an icon', inject(($compile: Function) => {
+        // expected rendered HTML:
+        // <a class="ms-Button ms-Button--hero">
+        //   <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--plus"></i></span>
+        //   <span class="ms-Button-label">Hero Button</span>
+        // </a>
+        // >>> REALLY should render
+        // <a class="ms-Button ms-Button--hero">
+        //   <span class="ms-Button-icon"><uif-icon uif-type="plus"></uif-icon></span>
+        //   <span class="ms-Button-label">Hero Button</span>
+        // </a>
+
+        let html: string = `<uif-button uif-type="hero" ng-href="http://ngOfficeUiFabric.com">
+                              <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+                            </uif-button>`;
+        let linkElement: JQuery = $compile(html)(scope);  // jqLite object
+        linkElement = jQuery(linkElement[0]);             // jQuery object
+
+        // verify class on inner label
+        expect(linkElement.children('span.ms-Button-label').length).toBe(1);
+        // verify icon was rendered by the directive
+        expect(linkElement.children('span.ms-Button-icon').length).toBe(1);
+      }));
+    }); // describe('hero button')
+
+  }); // describe('rendered as <a>')
+
+});

--- a/src/components/button/buttonDirective.ts
+++ b/src/components/button/buttonDirective.ts
@@ -1,0 +1,332 @@
+'use strict';
+
+import * as ng from 'angular';
+import {ButtonTypeEnum} from './buttonTypeEnum.ts';
+import {ButtonTemplateType} from './buttonTemplateType.ts';
+
+export interface IButtonScope extends ng.IScope {
+  disabled: boolean;
+  uifType: string;
+}
+export interface IButtonAttributes extends ng.IAttributes {
+  uifType: string;
+  ngHref: string;
+  disabled: string;
+}
+
+/**
+ * @controller
+ * @name ButtonController
+ * @private
+ * @description
+ * Used to more easily inject the Angular $log service into the directive.
+ */
+class ButtonController {
+  public static $inject: string[] = ['$log'];
+  constructor(public $log: ng.ILogService) { }
+}
+
+/**
+ * @ngdoc directive
+ * @name uifButton
+ * @module officeuifabric.components.button
+ * 
+ * @restrict E
+ * 
+ * @description
+ * `<uif-button>` is a button directive. This direcive implements multiple types 
+ * of buttons including action, primary, command, compound and hero buttons. Each type
+ * may also support inclusion of icons using the `<uif-icon>` directive. Buttons are 
+ * rendered as a `<button>` or `<a>` element depending in an `ng-href` attribute is
+ * specified. All buttons can be disabled by adding the `disabled` attribute
+ * 
+ * @see {link http://dev.office.com/fabric/components/button}
+ * 
+ * @usage
+ * 
+ * Regular buttons:
+ * <uif-button>Lorem Ipsum</uif-button>
+ * 
+ * Primary buttons:
+ * <uif-button uif-type="primary">Lorem Ipsum</uif-button>
+ * 
+ * Command buttons:
+ * <uif-button uif-type="command">Lorem Ipsum</uif-button>
+ * <uif-button uif-type="command">
+ *   <uif-icon uif-type="plus"></uif-icon>Lorem Ipsum
+ * </uif-button>
+ * 
+ * Compound buttons:
+ * <uif-button uif-type="Compound">Lorem Ipsum</uif-button>
+ * <uif-button uif-type="Compound">
+ *   Lorem Ipsum
+ *   <uif-button-description>Lorem Ipsum Description</uif-button-description>
+ * </uif-button>
+ * 
+ * Hero buttons:
+ * <uif-button uif-type="Hero">Lorem Ipsum</uif-button>
+ * <uif-button uif-type="Hero">
+ *   <uif-icon uif-type="plus"></uif-icon>
+ *   Lorem Ipsum
+ * </uif-button>
+ */
+export class ButtonDirective implements ng.IDirective {
+
+  public restrict: string = 'E';
+  public transclude: boolean = true;
+  public replace: boolean = true;
+  public scope: {} = {};
+  public controller: any = ButtonController;
+  public controllerAs: string = 'button';
+
+  public template: ng.IComponentTemplateFn = ($element: ng.IAugmentedJQuery, $attrs: IButtonAttributes) => {
+    // verify button type is supported
+    if (!ng.isUndefined($attrs.uifType) && ng.isUndefined(ButtonTypeEnum[$attrs.uifType])) {
+      this.$log.error('Error [ngOfficeUiFabric] officeuifabric.components.button - Unsupported button: ' +
+        'The button (\'' + $attrs.uifType + '\') is not supported by the Office UI Fabric. ' +
+        'Supported options are listed here: ' +
+        'https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/src/components/button/buttonTypeEnum.ts');
+    }
+
+    // determine template
+    switch ($attrs.uifType) {
+      // if hero, return button | link
+      case ButtonTypeEnum[ButtonTypeEnum.primary]:
+        return ng.isUndefined($attrs.ngHref)
+          ? this.templateOptions[ButtonTemplateType.primaryButton]
+          : this.templateOptions[ButtonTemplateType.primaryLink];
+      // if command, return button | link
+      case ButtonTypeEnum[ButtonTypeEnum.command]:
+        return ng.isUndefined($attrs.ngHref)
+          ? this.templateOptions[ButtonTemplateType.commandButton]
+          : this.templateOptions[ButtonTemplateType.commandLink];
+      // if compound, return button | link
+      case ButtonTypeEnum[ButtonTypeEnum.compound]:
+        return ng.isUndefined($attrs.ngHref)
+          ? this.templateOptions[ButtonTemplateType.compoundButton]
+          : this.templateOptions[ButtonTemplateType.compoundLink];
+      // if hero, return button | link
+      case ButtonTypeEnum[ButtonTypeEnum.hero]:
+        return ng.isUndefined($attrs.ngHref)
+          ? this.templateOptions[ButtonTemplateType.heroButton]
+          : this.templateOptions[ButtonTemplateType.heroLink];
+      // else no type specified, so it's an action button
+      default:
+        return ng.isUndefined($attrs.ngHref)
+          ? this.templateOptions[ButtonTemplateType.actionButton]
+          : this.templateOptions[ButtonTemplateType.actionLink];
+    }
+  };
+
+  // array of all the possibilities for a button
+  private templateOptions: { [buttonTemplateType: number]: string } = {};
+
+  constructor(private $log: ng.ILogService) {
+    this._populateHtmlTemplates();
+  }
+
+  public static factory(): ng.IDirectiveFactory {
+    const directive: ng.IDirectiveFactory = ($log: ng.ILogService) => new ButtonDirective($log);
+    directive.$inject = ['$log'];
+    return directive;
+  }
+
+  public compile(element: ng.IAugmentedJQuery,
+                 attrs: IButtonAttributes,
+                 transclude: ng.ITranscludeFunction): ng.IDirectivePrePost {
+    return {
+      post: this.postLink,
+      pre: this.preLink
+    };
+  }
+
+  /**
+   * Update the scope before linking everything up.
+   */
+  private preLink(scope: IButtonScope,
+                  element: ng.IAugmentedJQuery,
+                  attrs: IButtonAttributes,
+                  controllers: any,
+                  transclude: ng.ITranscludeFunction): void {
+    // if disabled, add the disabled attribute to the button/a tag
+    let disabled: boolean = 'disabled' in attrs;
+    scope.disabled = disabled;
+  }
+
+  /**
+   * Check the rendered HTML for anything that is invalid.
+   */
+  private postLink(scope: IButtonScope,
+                   element: ng.IAugmentedJQuery,
+                   attrs: IButtonAttributes,
+                   controllers: any,
+                   transclude: ng.ITranscludeFunction): void {
+
+    // if an icon was added to the button's contents for specific button types
+    //  that don't support icons, remove the icon
+    if (ng.isUndefined(attrs.uifType) ||
+        attrs.uifType === ButtonTypeEnum[ButtonTypeEnum.primary] ||
+        attrs.uifType === ButtonTypeEnum[ButtonTypeEnum.compound]) {
+      let iconElement: JQuery = element.find('uif-icon');
+      if (iconElement.length !== 0) {
+        iconElement.remove();
+        controllers.$log.error('Error [ngOfficeUiFabric] officeuifabric.components.button - ' +
+          'Icon not allowed in primary or compound buttons: ' +
+          'The primary & compound button does not support including icons in the body. ' +
+          'The icon has been removed but may cause rendering errors. Consider buttons that support icons such as command or hero.');
+      }
+    }
+
+    // create necessary wrappers around inner content in button depending on button type
+    transclude((clone: ng.IAugmentedJQuery) => {
+      let wrapper: ng.IAugmentedJQuery;
+
+      switch (attrs.uifType) {
+        // if type === command
+        case ButtonTypeEnum[ButtonTypeEnum.command]:
+          for (let i: number = 0; i < clone.length; i++) {
+            // wrap the button label
+            if (clone[i].tagName === 'SPAN') {
+              wrapper = ng.element('<span></span>');
+              wrapper.addClass('ms-Button-label').append(clone[i]);
+              element.append(wrapper);
+            }
+            // wrap the button's icon
+            if (clone[i].tagName === 'UIF-ICON') {
+              wrapper = ng.element('<span></span>');
+              wrapper.addClass('ms-Button-icon').append(clone[i]);
+              element.append(wrapper);
+            }
+          }
+          break;
+        // if type === compound
+        case ButtonTypeEnum[ButtonTypeEnum.compound]:
+          for (let i: number = 0; i < clone.length; i++) {
+            // if not a span, stop checking...
+            if (clone[i].tagName !== 'SPAN') {
+              continue;
+            }
+
+            // wrap the button label
+            if (clone[i].classList[0] === 'ng-scope' &&
+                clone[i].classList.length === 1) {
+              wrapper = ng.element('<span></span>');
+              wrapper.addClass('ms-Button-label').append(clone[i]);
+              element.append(wrapper);
+            // add the description... just add it to the button
+            } else {
+              element.append(clone[i]);
+            }
+          }
+          break;
+        // if type === hero
+        case ButtonTypeEnum[ButtonTypeEnum.hero]:
+          for (let i: number = 0; i < clone.length; i++) {
+            // wrap the label
+            if (clone[i].tagName === 'SPAN') {
+              wrapper = ng.element('<span></span>');
+              wrapper.addClass('ms-Button-label').append(clone[i]);
+              element.append(wrapper);
+            }
+            // wrap the icon
+            if (clone[i].tagName === 'UIF-ICON') {
+              wrapper = ng.element('<span></span>');
+              wrapper.addClass('ms-Button-icon').append(clone[i]);
+              element.append(wrapper);
+            }
+          }
+          break;
+        default:
+          break;
+      }
+    });
+
+  }
+
+  private _populateHtmlTemplates(): void {
+    // regular / action button
+    this.templateOptions[ButtonTemplateType.actionButton] =
+      `<button class="ms-Button" ng-class="{\'is-disabled\': disabled}">
+         <span class="ms-Button-label" ng-transclude></span>
+       </button>`;
+    this.templateOptions[ButtonTemplateType.actionLink] =
+      `<a class="ms-Button" ng-class="{\'is-disabled\': disabled}">
+         <span class="ms-Button-label" ng-transclude></span>
+       </a>`;
+
+    // primary button
+    this.templateOptions[ButtonTemplateType.primaryButton] =
+      `<button class="ms-Button ms-Button--primary" ng-class="{\'is-disabled\': disabled}">
+         <span class="ms-Button-label" ng-transclude></span>
+       </button>`;
+    this.templateOptions[ButtonTemplateType.primaryLink] =
+      `<a class="ms-Button ms-Button--primary" ng-class="{\'is-disabled\': disabled}">
+         <span class="ms-Button-label" ng-transclude></span>
+       </a>`;
+
+    // command button
+    this.templateOptions[ButtonTemplateType.commandButton] =
+      `<button class="ms-Button ms-Button--command" ng-class="{\'is-disabled\': disabled}"></button>`;
+    this.templateOptions[ButtonTemplateType.commandLink] =
+      `<a class="ms-Button ms-Button--command" ng-class="{\'is-disabled\': disabled}"></a>`;
+
+    // compound button
+    this.templateOptions[ButtonTemplateType.compoundButton] =
+      `<button class="ms-Button ms-Button--compound" ng-class="{\'is-disabled\': disabled}"></button>`;
+    this.templateOptions[ButtonTemplateType.compoundLink] =
+      `<a class="ms-Button ms-Button--compound" ng-class="{\'is-disabled\': disabled}"></a>`;
+
+    // hero button
+    this.templateOptions[ButtonTemplateType.heroButton] =
+      `<button class="ms-Button ms-Button--hero" ng-class="{\'is-disabled\': disabled}"></button>`;
+    this.templateOptions[ButtonTemplateType.heroLink] =
+      `<a class="ms-Button ms-Button--hero" ng-class="{\'is-disabled\': disabled}"></a>`;
+  }
+}
+
+
+/**
+ * @ngdoc directive
+ * @name uifDescriptionButton
+ * @module officeuifabric.components.button
+ * 
+ * @restrict E
+ * 
+ * @description
+ * `<uif-button-description>` is a button description directive.
+ * 
+ * @see {link http://dev.office.com/fabric/components/button}
+ * 
+ * @usage
+ * 
+ * <uif-button-description>Lorem Ipsum</uif-button-description>
+ */
+export class ButtonDescriptionDirective implements ng.IDirective {
+
+  public restrict: string = 'E';
+  public require: string = '^uifButton';
+  public transclude: boolean = true;
+  public replace: boolean = true;
+  public scope: boolean = false;
+  public template: string = '<span class="ms-Button-description" ng-transclude></span>';
+
+  public static factory(): ng.IDirectiveFactory {
+    const directive: ng.IDirectiveFactory = () => new ButtonDescriptionDirective();
+    return directive;
+  }
+
+}
+
+/**
+ * @ngdoc module
+ * @name officeuifabric.components.button
+ * 
+ * @description 
+ * Button
+ * 
+ */
+export var module: ng.IModule = ng.module('officeuifabric.components.button', [
+  'officeuifabric.components'
+])
+  .directive('uifButton', ButtonDirective.factory())
+  .directive('uifButtonDescription', ButtonDescriptionDirective.factory());

--- a/src/components/button/buttonTemplateType.ts
+++ b/src/components/button/buttonTemplateType.ts
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Enum for all possible button template types not public, only use within directive.
+ * 
+ * @readonly
+ * @private
+ * @enum {string}
+ * 
+ */
+export enum ButtonTemplateType {
+  actionButton,
+  actionLink,
+  primaryButton,
+  primaryLink,
+  commandButton,
+  commandLink,
+  compoundButton,
+  compoundLink,
+  heroButton,
+  heroLink,
+};

--- a/src/components/button/buttonTypeEnum.ts
+++ b/src/components/button/buttonTypeEnum.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Enum for all possible button types supported by Office UI Fabric. Enums in JavaScript are always indexed but this enum is
+ * intended to be used as a string.
+ * 
+ * @readonly
+ * @enum {string}
+ * @usage
+ * 
+ * This is used to generate the string that you pass into the <uif-button /> directive. Specifically, the string is passed 
+ * to the `uif-type` attribute. To evaluate the enum value as a string:
+ * 
+ * let buttonType: string = ButtonTypeEnum[ButtonTypeEnum.primary];
+ */
+export enum ButtonTypeEnum {
+  primary,
+  command,
+  compound,
+  hero
+};

--- a/src/components/button/demo/index.html
+++ b/src/components/button/demo/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>ngOfficeUiFabric | uif-button demo</title>
+  <meta charset="utf-8" />
+
+  <!-- office ui fabric css -->
+  <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.min.css" />
+  <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.components.min.css" />
+  <!-- angular library -->
+  <script src="../../../../node_modules/angular/angular.min.js"></script>
+  <!-- ngofficeuifabric library -->
+  <script src="../../../../dist/ngOfficeUiFabric.js"></script>
+  <script src="index.js"></script>
+</head>
+
+<body ng-app="demoApp">
+
+  <h1 class="ms-font-su">Button Demo | &lt;uif-button&gt;</h1>
+  <em>In order for this demo to work you must first build the library in debug mode.</em>
+
+  <h1>action (aka:regular) buttons</h1>
+  <uif-button>Button as button</uif-button>
+  <uif-button disabled>Button as button</uif-button>
+  <uif-button ng-href="http://ngOfficeUiFabric.com">Button as link</uif-button>
+  <uif-button disabled ng-href="http://ngOfficeUiFabric.com">Button as link</uif-button>
+
+  <h1>primary buttons</h1>
+  <uif-button uif-type="primary">PrimaryButton as button</uif-button>
+  <uif-button uif-type="primary" disabled>PrimaryButton as button</uif-button>
+  <uif-button uif-type="primary" ng-href="http://ngOfficeUiFabric.com">PrimaryButton as link</uif-button>
+  <uif-button uif-type="primary" disabled ng-href="http://ngOfficeUiFabric.com">PrimaryButton as link</uif-button>
+
+  <h1>command buttons</h1>
+  <uif-button uif-type="command">CommandButton as button</uif-button>
+  <uif-button uif-type="command" disabled>CommandButton as button</uif-button>
+  <uif-button uif-type="command" ng-href="http://ngOfficeUiFabric.com">CommandButton as link</uif-button>
+  <uif-button uif-type="command" disabled ng-href="http://ngOfficeUiFabric.com">CommandButton as link</uif-button>
+  <p />
+  <uif-button uif-type="command">
+    <uif-icon uif-type="alert"></uif-icon>CommandIcon as button
+  </uif-button>
+  <uif-button uif-type="command" disabled>
+    <uif-icon uif-type="alert"></uif-icon>CommandIcon as button
+  </uif-button>
+  <uif-button uif-type="command" ng-href="http://ngOfficeUiFabric.com">
+    <uif-icon uif-type="alert"></uif-icon>CommandIcon as link
+  </uif-button>
+  <uif-button uif-type="command" disabled ng-href="http://ngOfficeUiFabric.com">
+    <uif-icon uif-type="alert"></uif-icon>CommandIcon as link
+  </uif-button>
+
+  <h1>compound button</h1>
+  <uif-button uif-type="compound">CompoundButton as button</uif-button>
+  <uif-button uif-type="compound" disabled>CompoundButton as button</uif-button>
+  <p />
+  <uif-button uif-type="compound" ng-href="http://ngOfficeUiFabric.com">CompoundButton as link</uif-button>
+  <uif-button uif-type="compound" disabled ng-href="http://ngOfficeUiFabric.com">CompoundButton as link</uif-button>
+  <p />
+  <uif-button uif-type="compound">
+    CompoundDescription as button
+    <uif-button-description>CompoundDescription description</uif-button-description>
+  </uif-button>
+  <uif-button uif-type="compound" disabled>
+    CompoundDescription as button
+    <uif-button-description>CompoundDescription description</uif-button-description>
+  </uif-button>
+  <p />
+  <uif-button uif-type="compound" ng-href="http://ngOfficeUiFabric.com">
+    CompoundDescription as link
+    <uif-button-description>CompoundDescription description</uif-button-description>
+  </uif-button>
+  <uif-button uif-type="compound" disabled ng-href="http://ngOfficeUiFabric.com">
+    CompoundDescription as link
+    <uif-button-description>CompoundDescription description</uif-button-description>
+  </uif-button>
+
+
+  <h1>hero button</h1>
+  <uif-button uif-type="hero">HeroButton as button</uif-button>
+  <uif-button uif-type="hero" disabled>HeroButton as button</uif-button>
+  <p />
+  <uif-button uif-type="hero" ng-href="http://ngOfficeUiFabric.com">HeroButton as link</uif-button>
+  <uif-button uif-type="hero" disabled ng-href="http://ngOfficeUiFabric.com">HeroButton as link</uif-button>
+  <p />
+  <uif-button uif-type="hero">
+    <uif-icon uif-type="plus"></uif-icon>HeroIcon as button
+  </uif-button>
+  <uif-button uif-type="hero" disabled>
+    <uif-icon uif-type="plus"></uif-icon>HeroIcon as button
+  </uif-button>
+  <p />
+  <uif-button uif-type="hero" ng-href="http://ngOfficeUiFabric.com">
+    <uif-icon uif-type="plus"></uif-icon>HeroIcon as link
+  </uif-button>
+  <uif-button uif-type="hero" disabled ng-href="http://ngOfficeUiFabric.com">
+    <uif-icon uif-type="plus"></uif-icon>HeroIcon as link
+  </uif-button>
+
+
+</body>
+
+</html>

--- a/src/components/button/demo/index.js
+++ b/src/components/button/demo/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var demoApp = angular.module('demoApp', [
+  'officeuifabric.core',
+  'officeuifabric.components.button'
+]);

--- a/src/components/button/demoActionButton/index.html
+++ b/src/components/button/demoActionButton/index.html
@@ -1,0 +1,5 @@
+<!-- rendered as button -->
+<uif-button>Lorem Ipsum</uif-button>
+
+<!-- rendered as link -->
+<uif-button ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>

--- a/src/components/button/demoBasicUsage/index.html
+++ b/src/components/button/demoBasicUsage/index.html
@@ -1,0 +1,1 @@
+<uif-button>Lorem Ipsum</uif-button>

--- a/src/components/button/demoCommandButton/index.html
+++ b/src/components/button/demoCommandButton/index.html
@@ -1,0 +1,13 @@
+<!-- rendered as button -->
+<uif-button uif-type="command">Lorem Ipsum</uif-button>
+<!-- rendered as button with icon -->
+<uif-button uif-type="command">
+  <uif-icon uif-type="alert"></uif-icon>Lorem Ipsum
+</uif-button>
+
+<!-- rendered as link -->
+<uif-button uif-type="command" ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>
+<!-- rendered as link with icon -->
+<uif-button uif-type="command" ng-href="http://ngOfficeUiFabric.com">
+  <uif-icon uif-type="alert"></uif-icon>Lorem Ipsum
+</uif-button>

--- a/src/components/button/demoCompoundButton/index.html
+++ b/src/components/button/demoCompoundButton/index.html
@@ -1,0 +1,13 @@
+<!-- rendered as button -->
+<uif-button uif-type="hero">Lorem Ipsum</uif-button>
+<!-- rendered as button with icon -->
+<uif-button uif-type="hero">
+  <uif-button-description>Lorem Ipsum</uif-button-description>
+</uif-button>
+
+<!-- rendered as link -->
+<uif-button uif-type="hero" ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>
+<!-- rendered as link with icon -->
+<uif-button uif-type="hero" ng-href="http://ngOfficeUiFabric.com">
+  <uif-button-description>Lorem Ipsum</uif-button-description>
+</uif-button>

--- a/src/components/button/demoDisabled/index.html
+++ b/src/components/button/demoDisabled/index.html
@@ -1,0 +1,1 @@
+<uif-button disabled>Lorem Ipsum</uif-button>

--- a/src/components/button/demoHeroButton/index.html
+++ b/src/components/button/demoHeroButton/index.html
@@ -1,0 +1,13 @@
+<!-- rendered as button -->
+<uif-button uif-type="command">Lorem Ipsum</uif-button>
+<!-- rendered as button with icon -->
+<uif-button uif-type="command">
+  <uif-icon uif-type="alert"></uif-icon>Lorem Ipsum
+</uif-button>
+
+<!-- rendered as link -->
+<uif-button uif-type="command" ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>
+<!-- rendered as link with icon -->
+<uif-button uif-type="command" ng-href="http://ngOfficeUiFabric.com">
+  <uif-icon uif-type="alert"></uif-icon>Lorem Ipsum
+</uif-button>

--- a/src/components/button/demoPrimaryButton/index.html
+++ b/src/components/button/demoPrimaryButton/index.html
@@ -1,0 +1,5 @@
+<!-- rendered as button -->
+<uif-button uif-type="primary">Lorem Ipsum</uif-button>
+
+<!-- rendered as link -->
+<uif-button uif-type="primary" ng-href="http://ngOfficeUiFabric.com">Lorem Ipsum</uif-button>

--- a/src/core/components.ts
+++ b/src/core/components.ts
@@ -2,6 +2,7 @@
 
 import * as ng from 'angular';
 import * as calloutModule from '../components/callout/calloutDirective';
+import * as buttonModule from '../components/button/buttonDirective';
 import * as choicefieldModule from '../components/choicefield/choicefieldDirective';
 import * as contextualMenuModule from '../components/contextualmenu/contextualMenu';
 import * as dropdownModule from '../components/dropdown/dropdownDirective';
@@ -27,6 +28,7 @@ import * as toggleModule from '../components/toggle/toggleDirective';
  */
 export var module: ng.IModule = ng.module('officeuifabric.components', [
   calloutModule.module.name,
+  buttonModule.module.name,
   choicefieldModule.module.name,
   contextualMenuModule.module.name,
   dropdownModule.module.name,


### PR DESCRIPTION
This direcive implements multiple types of buttons including action, primary, command, compound and hero buttons. Each type may also support inclusion of icons using the `<uif-icon>` directive. Buttons are rendered as a `<button>` or `<a>` element depending in an `ng-href` attribute is specified. All buttons can be disabled by adding the `disabled` attribute.

Closes #14.
