### PR TITLE
fix(callout): updated demos & tests to use `uif-button`

### DIFF
--- a/src/components/callout/calloutDirective.spec.ts
+++ b/src/components/callout/calloutDirective.spec.ts
@@ -22,23 +22,28 @@ describe('calloutDirectives:', () => {
     }));
 
     it('main element should be DIV', () => {
+      element = jQuery(element[0]);
       let calloutElement: JQuery = element.children().first();
 
       expect(calloutElement[0].tagName === 'DIV').toBeTruthy();
     });
 
-    it('should not throw error on mouseenter and leave', () => {
+    it('should not throw error on mouseenter and leave', inject(($compile: ng.ICompileService) => {
+      let jqlElement: ng.IAugmentedJQuery = ng.element('<uif-callout></uif-callout>');
+      $compile(jqlElement)(scope);
+      scope.$digest();
 
-      element.triggerHandler('mouseenter');
+      jqlElement.triggerHandler('mouseenter');
       scope.$digest();
 
       expect(() => {
-        element.triggerHandler('mouseleave');
+        jqlElement.triggerHandler('mouseleave');
       }).not.toThrow(new Error('[$compile:nonassign] Expression \'undefined\' ' +
       'used with directive \'uifCallout\' is non-assignable!\n' +
       'http://errors.angularjs.org/1.4.9/$compile/nonassign?p0=undefined&p1=uifCallout'));
 
-    });
+
+    }));
 
     it('main element should have callout CSS class', () => {
       let calloutElement: JQuery = element.find('div').first();
@@ -307,49 +312,47 @@ describe('calloutDirectives:', () => {
     }));
 
     it('should close by itself when mouse outside callout', inject(($compile: ng.ICompileService) => {
-        element = ng.element('<uif-callout ng-show="vm.isOpen"></uif-callout>');
+      let jqlElement: ng.IAugmentedJQuery = ng.element('<uif-callout ng-show="vm.isOpen"></uif-callout>');
+      scope.vm.isOpen = true;
+      $compile(jqlElement)(scope);
+      scope.$digest();
 
-        scope.vm.isOpen = true;
+      let jqueryElement: JQuery = jQuery(jqlElement[0]);
+      expect(jqueryElement[0]).not.toHaveClass('ng-hide');
 
-        $compile(element)(scope);
-        scope.$digest();
+      jqlElement.triggerHandler('mouseenter');
+      scope.$digest();
+      expect(jqueryElement[0]).not.toHaveClass('ng-hide');
 
-        element = jQuery(element[0]);
+      jqlElement.triggerHandler('mouseleave');
+      scope.$digest();
+      expect(jqueryElement[0]).toHaveClass('ng-hide');
 
-        let callout: JQuery = element.eq(0);
-        callout.mouseenter();
-        scope.$digest();
-
-        expect(element[0]).not.toHaveClass('ng-hide');
-
-        scope.vm.isOpen = false;
-        callout.mouseleave();
-        scope.$digest();
-        expect(element[0]).toHaveClass('ng-hide');
     }));
 
     it('should close itself when mouse over callout and close button clicked', inject(($compile: ng.ICompileService) => {
-        element = ng.element('<uif-callout ng-show="vm.isOpen" uif-close></uif-callout>');
+        let jqlElement: ng.IAugmentedJQuery = ng.element('<uif-callout ng-show="vm.isOpen" uif-close></uif-callout>');
+        element = jQuery(jqlElement[0]);
+
 
         scope.vm.isOpen = true;
-
         $compile(element)(scope);
         scope.$digest();
 
-        element = jQuery(element);
-
-        let callout: JQuery = element.eq(0);
-        callout.mouseenter();
+        jqlElement.triggerHandler('mouseenter');
         scope.$digest();
 
         expect(element[0]).not.toHaveClass('ng-hide');
 
-        let closeButton: JQuery = element.find('button.ms-Callout-close').eq(0);
-        closeButton.click();
+        let closeButton: JQuery = jqlElement.find('button').eq(0);
+        closeButton.triggerHandler('click');
         scope.$digest();
 
         expect(element[0]).toHaveClass('ng-hide');
     }));
+
+
+
 
     it('should not close when mouse moves outside callout but there is close button', inject(($compile: ng.ICompileService) => {
         element = ng.element('<uif-callout ng-show="vm.isOpen" uif-close></uif-callout>');
@@ -359,15 +362,12 @@ describe('calloutDirectives:', () => {
         $compile(element)(scope);
         scope.$digest();
 
-        element = jQuery(element[0]);
-
-        let callout: JQuery = element.eq(0);
-        callout.mouseenter();
+        element.triggerHandler('mouseenter');
         scope.$digest();
 
         expect(element[0]).not.toHaveClass('ng-hide');
 
-        callout.mouseleave();
+        element.triggerHandler('mouseleave');
         scope.$digest();
 
         expect(element[0]).not.toHaveClass('ng-hide');
@@ -550,14 +550,14 @@ describe('calloutDirectives:', () => {
     it('action buttons get proper CSS when uif-actiontext is used', inject(($compile: ng.ICompileService) => {
       element = ng.element('<uif-callout uif-action-text>' +
       '<uif-callout-actions>' +
-      '<button class="ms-Button ms-Button--command">' +
-      '<span class="ms-Button-icon"><i class="ms-Icon ms-Icon--check"></i></span>' +
-      '<span class="ms-Button-label">Save</span>' +
-      '</button>' +
-      '<button class="ms-Button ms-Button--command">' +
-      '<span class="ms-Button-icon"><i class="ms-Icon ms-Icon--x"></i></span>' +
-      '<span class="ms-Button-label">Cancel</span>' +
-      '</button>' +
+      '<uif-button uif-type="command">' +
+      '<uif-icon uif-type="check"></uif-icon>' +
+      'Save' +
+      '</uif-button>' +
+      '<uif-button uif-type="command">' +
+      '<uif-icon uif-type="x"></uif-icon>' +
+      'Cancel' +
+      '</uif-button>' +
       '</uif-callout-actions>' +
       '</uif-callout>');
 
@@ -577,11 +577,11 @@ describe('calloutDirectives:', () => {
       expect(secondButton).toHaveClass('ms-Callout-action');
 
 
-      let firstButtonSpans: JQuery = firstButton.find('span');
+      let firstButtonSpans: JQuery = firstButton.children('span')
       expect(firstButtonSpans.length).toBe(2);
       expect(firstButtonSpans).toHaveClass('ms-Callout-actionText');
 
-      let secondButtonSpans: JQuery = secondButton.find('span');
+      let secondButtonSpans: JQuery = secondButton.children('span');
       expect(secondButtonSpans.length).toBe(2);
       expect(secondButtonSpans).toHaveClass('ms-Callout-actionText');
     }));
@@ -589,10 +589,10 @@ describe('calloutDirectives:', () => {
     it('action links get proper CSS when uif-actiontext is used', inject(($compile: ng.ICompileService) => {
       element = ng.element('<uif-callout uif-action-text>' +
       '<uif-callout-actions>' +
-      '<a class="ms-Button ms-Button--command">' +
-      '<span class="ms-Button-icon"><i class="ms-Icon ms-Icon--x"></i></span>' +
-      '<span class="ms-Button-label">Cancel</span>' +
-      '</a>' +
+      '<uif-button uif-type="command" ng-href="#">' +
+      '<uif-icon uif-type="x"></uif-icon>' +
+      'Cancel' +
+      '</uif-button>' +
       '</uif-callout-actions>' +
       '</uif-callout>');
 
@@ -609,10 +609,14 @@ describe('calloutDirectives:', () => {
 
       expect(firstAction).toHaveClass('ms-Callout-action');
 
-      let firstActionSpans: JQuery = firstAction.find('span');
+      let firstActionSpans: JQuery = firstAction.children('span');
       expect(firstActionSpans.length).toBe(2);
       expect(firstActionSpans).toHaveClass('ms-Callout-actionText');
 
+      // deepest span should not have the ms-Callout-actionText class
+      let deepestSpan: JQuery = firstActionSpans.children('span');
+      expect(deepestSpan.length).toBe(1);
+      expect(deepestSpan).not.toHaveClass('ms-Callout-actionText');
     }));
 
 

--- a/src/components/callout/calloutDirective.ts
+++ b/src/components/callout/calloutDirective.ts
@@ -126,34 +126,29 @@ export class CalloutActionsDirective implements ng.IDirective {
 
     if (ng.isObject(calloutController)) {
       calloutController.$scope.$watch('hasSeparator', (hasSeparator: boolean) => {
-        let actionChildren: JQuery = instanceElement.children().eq(0).children();
+        if (hasSeparator) {
+          let actionChildren: JQuery = instanceElement.children().eq(0).children();
 
-        for (let buttonIndex: number = 0; buttonIndex < actionChildren.length; buttonIndex++) {
-          let action: JQuery = actionChildren.eq(buttonIndex);
-          // handle CSS on button
-          if (hasSeparator) {
+          for (let buttonIndex: number = 0; buttonIndex < actionChildren.length; buttonIndex++) {
+            let action: JQuery = actionChildren.eq(buttonIndex);
+            // handle CSS on button
             action.addClass('ms-Callout-action');
-          } else {
-            action.removeClass('ms-Callout-action');
-          }
 
-          // take care of span inside buttons
-          let actionSpans: JQuery = action.find('span');
+            // take care of span inside buttons
+            let actionSpans: JQuery = action.find('span');
 
-          for (let spanIndex: number = 0; spanIndex < actionSpans.length; spanIndex++) {
-            let actionSpan: JQuery = actionSpans.eq(spanIndex);
-
-            if (hasSeparator) {
-              actionSpan.addClass('ms-Callout-actionText');
-            } else {
-              actionSpan.removeClass('ms-Callout-actionText');
+            // add only to spans that are either button label or icon
+            for (let spanIndex: number = 0; spanIndex < actionSpans.length; spanIndex++) {
+              let actionSpan: JQuery = actionSpans.eq(spanIndex);
+              if (actionSpan.hasClass('ms-Button-label') || actionSpan.hasClass('ms-Button-icon')) {
+                actionSpan.addClass('ms-Callout-actionText');
+              }
             }
           }
         }
       });
     }
   }
-
 }
 
 /**

--- a/src/components/callout/demo/index.html
+++ b/src/components/callout/demo/index.html
@@ -1,28 +1,28 @@
 <!DOCTYPE html>
 <html>
 
-  <head>
-    <title>ngOfficeUiFabric | uif-Callout demo</title>
-    <meta charset="utf-8">
+<head>
+  <title>ngOfficeUiFabric | uif-Callout demo</title>
+  <meta charset="utf-8">
 
-    <!-- office ui fabric css -->
-    <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.min.css" />
-    <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.components.min.css" />
-    <!-- angular library -->
-    <script src="../../../../node_modules/angular/angular.min.js"></script>
-    <!-- ngofficeuifabric library -->
-    <script src="../../../../dist/ngOfficeUiFabric.js"></script>
-    <script src="index.js"></script>
-  </head>
+  <!-- office ui fabric css -->
+  <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.min.css" />
+  <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.components.min.css" />
+  <!-- angular library -->
+  <script src="../../../../node_modules/angular/angular.min.js"></script>
+  <!-- ngofficeuifabric library -->
+  <script src="../../../../dist/ngOfficeUiFabric.js"></script>
+  <script src="index.js"></script>
+</head>
 
-  <body ng-app="demoApp">
-    <h1 class="ms-font-su">Callout Demo | &lt;uif-callout&gt;</h1>
-    <em>In order for this demo to work you must first build the library in debug mode.</em>
+<body ng-app="demoApp">
+  <h1 class="ms-font-su">Callout Demo | &lt;uif-callout&gt;</h1>
+  <em>In order for this demo to work you must first build the library in debug mode.</em>
 
-    <!-- first example -->
-    <p>To render callout, use the following markup:
-      <br/>
-      <pre>
+  <!-- first example -->
+  <p>To render callout, use the following markup:
+    <br/>
+    <pre>
   &lt;uif-callout uif-arrow=&quot;left&quot;&gt;
     &lt;uif-callout-header&gt;All of your favorite people&lt;/uif-callout-header&gt;
     &lt;uif-callout-content&gt;Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.&lt;/uif-callout-content&gt;
@@ -31,23 +31,23 @@
     &lt;/uif-callout-actions&gt;
   &lt;/uif-callout&gt;
       </pre>
-    </p>
+  </p>
 
-    <p>
-      <uif-callout uif-arrow="left">
-        <uif-callout-header>All of your favorite people</uif-callout-header>
-        <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
-        <uif-callout-actions>
-          <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
-        </uif-callout-actions>
-      </uif-callout>
-    </p>
+  <p>
+    <uif-callout uif-arrow="left">
+      <uif-callout-header>All of your favorite people</uif-callout-header>
+      <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
+      <uif-callout-actions>
+        <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
+      </uif-callout-actions>
+    </uif-callout>
+  </p>
 
-    <!-- second example -->
-    <p>
-      This markup will render OOBE callout:
-      <br/>
-      <pre>
+  <!-- second example -->
+  <p>
+    This markup will render OOBE callout:
+    <br/>
+    <pre>
   &lt;uif-callout uif-arrow=&quot;top&quot; uif-type=&quot;oobe&quot;&gt;
     &lt;uif-callout-header&gt;All of your favorite people&lt;/uif-callout-header&gt;
     &lt;uif-callout-content&gt;People automatically puts together all of the people you care most about in one place.&lt;/uif-callout-content&gt;
@@ -63,29 +63,29 @@
     &lt;/uif-callout-actions&gt;
   &lt;/uif-callout&gt;
       </pre>
-    </p>
+  </p>
 
-    <p>
-      <uif-callout uif-arrow="top" uif-type="oobe">
-        <uif-callout-header>All of your favorite people</uif-callout-header>
-        <uif-callout-content>People automatically puts together all of the people you care most about in one place.</uif-callout-content>
-        <uif-callout-actions>
-          <button class="ms-Callout-button ms-Button ms-Button--primary">
-            <span class="ms-Button-label">More</span>
-            <span class="ms-Button-description">Description of the action this button takes</span>
-          </button>
-          <button class="ms-Callout-button ms-Button">
-            <span class="ms-Button-label">Got it</span>
-            <span class="ms-Button-description">Description of the action this button takes</span>
-          </button>
-        </uif-callout-actions>
-      </uif-callout>
-    </p>
+  <p>
+    <uif-callout uif-arrow="top" uif-type="oobe">
+      <uif-callout-header>All of your favorite people</uif-callout-header>
+      <uif-callout-content>People automatically puts together all of the people you care most about in one place.</uif-callout-content>
+      <uif-callout-actions>
+        <uif-button uif-type="primary">
+          More
+          <uif-button-description>Description of the action this button takes</uif-button-description>
+        </uif-button>
+        <uif-button>
+          Got it
+          <uif-button-description>Description of the action this button takes</uif-button-description>
+        </uif-button>
+      </uif-callout-actions>
+    </uif-callout>
+  </p>
   <!-- third example -->
-    <p>
-      This markup will render Peek callout:
-      <br/>
-      <pre>
+  <p>
+    This markup will render Peek callout:
+    <br/>
+    <pre>
   &lt;uif-callout uif-arrow=&quot;right&quot; uif-type=&quot;peek&quot;&gt;
     &lt;uif-callout-header&gt;Uploaded 2 items to &lt;span class=&quot;ms-Link&quot;&gt;Alton&apos;s OneDrive&lt;/span&gt;&lt;/uif-callout-header&gt;
     &lt;uif-callout-actions&gt;
@@ -96,26 +96,26 @@
     &lt;/uif-callout-actions&gt;
   &lt;/uif-callout&gt;
       </pre>
-    </p>
+  </p>
 
-    <p>
-      <uif-callout uif-arrow="right" uif-type="peek">
-        <uif-callout-header>Uploaded 2 items to <span class="ms-Link">Alton's OneDrive</span></uif-callout-header>
-        <uif-callout-actions>
-          <button class="ms-Callout-button ms-Button">
-            <span class="ms-Button-label">More</span>
-            <span class="ms-Button-description">Description of the action this button takes</span>
-          </button>
-        </uif-callout-actions>
-      </uif-callout>
-    </p>
+  <p>
+    <uif-callout uif-arrow="right" uif-type="peek">
+      <uif-callout-header>Uploaded 2 items to <span class="ms-Link">Alton's OneDrive</span></uif-callout-header>
+      <uif-callout-actions>
+        <uif-button>
+          More
+          <uif-button-description>Description of the action this button takes</uif-button-description>
+        </uif-button>
+      </uif-callout-actions>
+    </uif-callout>
+  </p>
 
   <!-- fourth example -->
 
-    <p>
-      Separator can be rendered between content and actions containers. <em>uif-actiontext</em> and <em>uif-separator</em> server the same purpose.
-      <br/>
-      <pre>
+  <p>
+    Separator can be rendered between content and actions containers. <em>uif-actiontext</em> and <em>uif-separator</em>    server the same purpose.
+    <br/>
+    <pre>
   &lt;uif-callout uif-action-text&gt;
     &lt;uif-callout-header&gt;All of your favorite people&lt;/uif-callout-header&gt;
     &lt;uif-callout-content&gt;People automatically puts together all of the people you care most about in one place.&lt;/uif-callout-header&gt;
@@ -131,31 +131,31 @@
     &lt;/uif-callout-actions&gt;
   &lt;/uif-callout&gt;
       </pre>
-    </p>
+  </p>
 
-    <p>
-      <uif-callout uif-action-text>
-        <uif-callout-header>All of your favorite people</uif-callout-header>
-        <uif-callout-content>People automatically puts together all of the people you care most about in one place.</uif-callout-header>
+  <p>
+    <uif-callout uif-action-text>
+      <uif-callout-header>All of your favorite people</uif-callout-header>
+      <uif-callout-content>People automatically puts together all of the people you care most about in one place.</uif-callout-header>
         <uif-callout-actions>
-          <button class="ms-Button ms-Button--command">
-            <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--check"></i></span>
-            <span class="ms-Button-label">Save</span>
-          </button>
-          <button class="ms-Button ms-Button--command">
-            <span class="ms-Button-icon"><i class="ms-Icon ms-Icon--x"></i></span>
-            <span class="ms-Button-label">Cancel</span>
-          </button>
+          <uif-button uif-type="command">
+            <uif-icon uif-type="check"></uif-icon>
+            Save
+          </uif-button>
+          <uif-button uif-type="command">
+            <uif-icon uif-type="x"></uif-icon>
+            Cancel
+          </uif-button>
         </uif-callout-actions>
-      </uif-callout>
-    </p>
+    </uif-callout>
+  </p>
 
   <!-- fifth example -->
 
-    <div ng-controller="calloutDemoController">
-      <p>Callout supports <em>ngShow</em> directive. Hover over the link to test.
-        <br/>
-        <pre>
+  <div ng-controller="calloutDemoController">
+    <p>Callout supports <em>ngShow</em> directive. Hover over the link to test.
+      <br/>
+      <pre>
   &lt;uif-callout ng-show=&quot;vm.firstVisible&quot; uif-arrow=&quot;left&quot;&gt;
     &lt;uif-callout-header&gt;All of your favorite people&lt;/uif-callout-header&gt;
     &lt;uif-callout-content&gt;Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.&lt;/uif-callout-content&gt;
@@ -164,25 +164,25 @@
     &lt;/uif-callout-actions&gt;
   &lt;/uif-callout&gt;
         </pre>
-      </p>
-      <div>
-        <a href="#" ng-mouseenter="vm.firstVisible = true" ng-mouseleave="vm.firstVisible = false">Hover over me!</a>
-      </div>
-      <div>
-        <uif-callout ng-show="vm.firstVisible" uif-arrow="left">
-          <uif-callout-header>All of your favorite people</uif-callout-header>
-          <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
-          <uif-callout-actions>
-            <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
-          </uif-callout-actions>
-        </uif-callout>
-      </div>
+    </p>
+    <div>
+      <a href="#" ng-mouseenter="vm.firstVisible = true" ng-mouseleave="vm.firstVisible = false">Hover over me!</a>
+    </div>
+    <div>
+      <uif-callout ng-show="vm.firstVisible" uif-arrow="left">
+        <uif-callout-header>All of your favorite people</uif-callout-header>
+        <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
+        <uif-callout-actions>
+          <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
+        </uif-callout-actions>
+      </uif-callout>
+    </div>
 
-  <!-- fifth example -->
+    <!-- fifth example -->
 
-      <p>Callout can have close button, with help of <em>uif-close</em> attribute.
-        <br/>
-        <pre>
+    <p>Callout can have close button, with help of <em>uif-close</em> attribute.
+      <br/>
+      <pre>
   &lt;uif-callout ng-show=&quot;vm.secondVisible&quot; uif-arrow=&quot;left&quot; uif-close&gt;
     &lt;uif-callout-header&gt;All of your favorite people&lt;/uif-callout-header&gt;
     &lt;uif-callout-content&gt;Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.&lt;/uif-callout-content&gt;
@@ -191,25 +191,25 @@
     &lt;/uif-callout-actions&gt;
   &lt;/uif-callout&gt;
         </pre>
-      </p>
-      <div>
-        <button ng-click="vm.secondVisible = !vm.secondVisible">Click me!</button>
-      </div>
-      <div>
-        <uif-callout ng-show="vm.secondVisible" uif-arrow="left" uif-close>
-          <uif-callout-header>All of your favorite people</uif-callout-header>
-          <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
-          <uif-callout-actions>
-            <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
-          </uif-callout-actions>
-        </uif-callout>
-      </div>
+    </p>
+    <div>
+      <button ng-click="vm.secondVisible = !vm.secondVisible">Click me!</button>
+    </div>
+    <div>
+      <uif-callout ng-show="vm.secondVisible" uif-arrow="left" uif-close>
+        <uif-callout-header>All of your favorite people</uif-callout-header>
+        <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
+        <uif-callout-actions>
+          <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
+        </uif-callout-actions>
+      </uif-callout>
+    </div>
 
-  <!-- sixth example -->
+    <!-- sixth example -->
 
-      <p>When <em>ngShow</em> is used without <em>uif-close</em>, callout is closed when mouse leaves from callout:
-        <br/>
-        <pre>
+    <p>When <em>ngShow</em> is used without <em>uif-close</em>, callout is closed when mouse leaves from callout:
+      <br/>
+      <pre>
   &lt;uif-callout ng-show=&quot;vm.thirdVisible&quot; uif-arrow=&quot;left&quot;&gt;
     &lt;uif-callout-header&gt;All of your favorite people&lt;/uif-callout-header&gt;
     &lt;uif-callout-content&gt;Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.&lt;/uif-callout-content&gt;
@@ -218,20 +218,20 @@
     &lt;/uif-callout-actions&gt;
   &lt;/uif-callout&gt;
         </pre>
-      </p>
-      <div>
-        <button ng-click="vm.thirdVisible = !vm.thirdVisible">Click me!</button>
-      </div>
-      <div>
-        <uif-callout ng-show="vm.thirdVisible" uif-arrow="left">
-          <uif-callout-header>All of your favorite people</uif-callout-header>
-          <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
-          <uif-callout-actions>
-            <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
-          </uif-callout-actions>
-        </uif-callout>
-      </div>
+    </p>
+    <div>
+      <button ng-click="vm.thirdVisible = !vm.thirdVisible">Click me!</button>
     </div>
-  </body>
+    <div>
+      <uif-callout ng-show="vm.thirdVisible" uif-arrow="left">
+        <uif-callout-header>All of your favorite people</uif-callout-header>
+        <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
+        <uif-callout-actions>
+          <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
+        </uif-callout-actions>
+      </uif-callout>
+    </div>
+  </div>
+</body>
 
 </html>


### PR DESCRIPTION
Updated demos & tests to use `uif-button` directive instead of plain HTML button elements.

Logic applying CSS classes to button in callout action has been also simplified and general code coverage for the callout component has been increased by minor fixes to the tests.

Closes #182.
