### PR TITLE
chore(): automate release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/.DS_Store
+**/npm-debug.log
 
 # no need to keep stuff pulled remotely
 node_modules

--- a/scripts/update-pkg-versions.sh
+++ b/scripts/update-pkg-versions.sh
@@ -68,7 +68,7 @@ function run {
 
   # clone packaging repo
   echo ".. clone packaging repo"
-  git clone https://github.com/andrewconnell/package-ngofficeuifabric \
+  git clone https://github.com/ngOfficeUIFabric/package-ngofficeuifabric \
     $PKG_PATH --depth=2
 
 

--- a/scripts/update-pkg-versions.sh
+++ b/scripts/update-pkg-versions.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# NOTE: DO NOT RUN THIS SCRIPT UNLESS CREATING A RELEASE!!!!!!!!
+#   This should only be done by the project owner(s). If it is run by mistake, it will
+#   require cleanup in the main repos resulting in rewriting history & likey screwingup
+#   most forks.
+#
+# This script is only used when creating a new release. It expects the following:
+#   1. to be run from the `master` branch
+#   2. all updates to be included in the release that need to be applied 
+#       have been applied to local `master` including updating package.json to 
+#       the desired release version, the correct angular, office ui fabric & other
+#       dependencies & the changelog.md has been updated
+#
+# The script will do the following things:
+#   1. remove any previous compiles in `/dist`
+#   2. get the version from this repo's pacakge.json - this will be the version 
+#       of the release
+#   3. compile the library to production & debug mode
+#   4. clone a copy of package-ngofficeuifabric to a temp location
+#   5. copy the compiled library & changelog to the cloned package-ngofficeuifabric
+#   6. update the package-ngofficeuifabric repo with the following changes by calling
+#       update-pkg-versions.js:
+#     6.1. update bower.json with current library dependencies
+#     6.2. update bower.json with current library version
+#     6.3. update package.json with current library dependencies
+#     6.4. update package.json with current library version
+#   7. update this repo's origin master:
+#     7.1. push any pending commits => origin master
+#     7.2. tag with the current version & push tags to origin
+#   8. update the cloned package repo's origin master:
+#     8.1. add all changed files
+#     8.2. commit everything with comment "release(): [version]"
+#     8.3. push commit => origin master
+#     8.4. tag with the current version & push tags to origin
+#   9. remove cloned package repo temp folder
+#
+# Usage:
+# $ sh update-pkg-versions.sh --git-push-dryrun=(true|false)
+# ^^^ this will default to --git-push-dryrun=true meaning that all git push commands
+#     will have the `--dry-run` argument added and thus, nothing is push to remotes
+# ^^^ to ensure these things run, you must specify --git-push-dryrun=false
+
+function init {
+  # setup paths
+  SRC_PATH=$PWD
+  PKG_PATH="$(mktemp -d)"
+}
+
+function run {
+  cd ..
+
+
+  # pre cleaning
+  echo ".. pre cleaning"
+  rm -Rf dist
+
+
+  # get version
+  VERSION="$(readJsonProp "package.json" "version")"
+
+
+  # compile production & debug library
+  echo ".. compiling prod & debug library"
+  gulp build-lib
+  gulp build-lib --dev
+
+
+  # clone packaging repo
+  echo ".. clone packaging repo"
+  git clone https://github.com/andrewconnell/package-ngofficeuifabric \
+    $PKG_PATH --depth=2
+
+
+  # copy built library & changelog
+  echo ".. copying built library & changelog"
+  cp -Rf dist/*.js $PKG_PATH
+  cp -Rf changelog.md $PKG_PATH/changelog.md
+
+
+  # update versions & dependencies in package.json & bower.json
+  echo ".. updating versions & dependencies in package.json & bower.json"
+  node scripts/update-pkg-versions.js --src=$PWD --pkg=$PKG_PATH
+
+
+  # update source repo
+  echo ".. updating source repo ng-officeuifabric"
+  cd $SRC_PATH
+
+  echo ".. .. pushing origin master"
+  git push -q origin master
+
+  echo ".. .. adding tag for version $VERSION & pushing orign master"
+  git tag -f $VERSION
+  git push --tags
+
+
+  # update packaging repo
+  echo ".. updating packaging repo package-ngofficeuifabric"
+  cd $PKG_PATH
+
+  echo ".. .. adding & commiting changes to package repo"
+  git add -A
+
+  git commit -m "release(): $VERSION"
+  echo ".. .. pushing origin master"
+  git push -q origin master
+
+  echo ".. .. adding tag for version $VERSION & pushing orign master"
+  git tag -f $VERSION
+  git push --tags
+
+
+  # remove temp folder
+  echo ".. removing temp folder at:"
+  echo ".. .. $PKG_PATH"
+  cd $SRC_PATH
+  rm -rf $PKG_PATH
+}
+
+source $(dirname $0)/utils.inc

--- a/scripts/update-pkg-versions.ts
+++ b/scripts/update-pkg-versions.ts
@@ -1,0 +1,97 @@
+// updates the package.json & bower.json in the ngOfficeUiFabric packaging 
+// repo (package-ngofficeuifabric) to have the same version & dependencies 
+// that are specified in the main source repo's (ng-officeuifabric)
+// package.json file
+//
+// two parameters are expected:
+// --src = location of the cloned source repo (ng-officeuifabric)
+// --pkg = location of the cloned package repo (ngofficeuifabric)
+
+'use strict';
+
+import * as fs from 'fs';
+import * as yargs from 'yargs';
+
+// verify required params passed in
+if (!yargs.argv.src || !yargs.argv.pkg) {
+  console.error('must specify the path to \'--src\' & \'--pkg\'');
+  process.exit();
+}
+
+// get library version & dependencies
+let libraryVersion: string = getLibraryVersion(yargs.argv.src);
+let deps: ILibraryDependencies = getDependencies(yargs.argv.src);
+
+// update bower
+let bowerManifest: any = require(yargs.argv.pkg + '/bower.json');
+bowerManifest.version = libraryVersion;
+bowerManifest.dependencies = {
+  'angular': deps.angularLib,
+  'office-ui-fabric': deps.officeUiFabricLib
+};
+// write bower file back
+fs.writeFileSync(yargs.argv.pkg + '/bower.json', JSON.stringify(bowerManifest, null, 2));
+
+
+// update package
+let packageManifest: any = require(yargs.argv.pkg + '/package.json');
+packageManifest.version = libraryVersion;
+packageManifest.dependencies = {
+  'angular': deps.angularLib,
+  'office-ui-fabric': deps.officeUiFabricLib
+};
+// write bower file back
+fs.writeFileSync(yargs.argv.pkg + '/package.json', JSON.stringify(packageManifest, null, 2));
+
+
+/* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ */
+
+
+/**
+ * Gets the version of the library from the package.json file unless
+ * the version is specified as the enviroment variable VERSION.
+ * 
+ * @param  {string} sourcePath - location where the source repo resides
+ *
+ * @returns string
+ */
+function getLibraryVersion(sourcePath: string): string {
+  if (process.env.VERSION === undefined) {
+    return require(sourcePath + '/package.json').version;
+  } else {
+    return process.env.VERSION;
+  }
+}
+/**
+ * Gets the library dependencies in the current library from the
+ * package.json.
+ * 
+ * @param  {string} sourcePath - location where the source repo resides
+ * 
+ * @returns ILibraryDependencies
+ */
+function getDependencies(sourcePath: string): ILibraryDependencies {
+  // get the dependencies
+  let libDeps: any = require(sourcePath + '/package.json').dependencies;
+
+  // create new dep object & export
+  let dependencies: ILibraryDependencies = {
+    angularLib: libDeps.angular,
+    officeUiFabricLib: libDeps['office-ui-fabric']
+  };
+
+  return dependencies;
+}
+
+/**
+ * Library version dependencies this library has.
+ * 
+ * @typedef libraryDependencies
+ * @type {Object}
+ * @prop {string?}   angular        - Version of Angular required.
+ * @prop {string?}   officeUiFabric - Version of the Office UI Fabric required.
+ */
+interface ILibraryDependencies {
+  angularLib?: string;
+  officeUiFabricLib?: string;
+}

--- a/scripts/utils.inc
+++ b/scripts/utils.inc
@@ -1,0 +1,282 @@
+# bash utils from angularjs
+
+# This file provides:
+# - a default control flow
+#   * initializes the environment
+#   * able to mock "git push" in your script and in all sub scripts
+#   * call a function in your script based on the arguments
+# - named argument parsing and automatic generation of the "usage" for your script
+# - intercepting "git push" in your script and all sub scripts
+# - utility functions
+#
+# Usage:
+# - define the variable ARGS_DEF (see below) with the arguments for your script
+# - include this file using `source utils.inc` at the end of your script.
+#
+# Default control flow:
+# 0. Set the current directory to the directory of the script. By this
+#    the script can be called from anywhere.
+# 1. Parse the named arguments
+# 2. If the parameter "git_push_dryrun" is set, all calls the `git push` in this script
+#    or in child scripts will be intercepted so that the `--dry-run` and `--porcelain` is added
+#    to show what the push would do but not actually do it.
+# 3. If the parameter "verbose" is set, the `-x` flag will be set in bash.
+# 4. The function "init" will be called if it exists
+# 5. If the parameter "action" is set, it will call the function with the name of that parameter.
+#    Otherwise the function "run" will be called.
+#
+# Named Argument Parsing:
+# - The variable ARGS_DEF defines the valid command arguments
+#   * Required args syntax: --paramName=paramRegex
+#   * Optional args syntax: [--paramName=paramRegex]
+#   * e.g. ARG_DEFS=("--required_param=(.+)" "[--optional_param=(.+)]")
+# - Checks that:
+#   * all arguments match to an entry in ARGS_DEF
+#   * all required arguments are present
+#   * all arguments match their regex
+# - Afterwards, every paramter value will be stored in a variable
+#   with the name of the parameter in upper case (with dash converted to underscore).
+#
+# Special arguments that are always available:
+# - "--action=.*": This parameter will be used to dispatch to a function with that name when the
+#   script is started
+# - "--git_push_dryrun=true": This will intercept all calls to `git push` in this script
+#   or in child scripts so that the `--dry-run` and `--porcelain` is added
+#   to show what the push would do but not actually do it.
+# - "--verbose=true": This will set the `-x` flag in bash so that all calls will be logged
+#
+# Utility functions:
+# - readJsonProp
+# - replaceJsonProp
+# - resolveDir
+# - getVar
+# - serVar
+# - isFunction
+
+# always stop on errors
+set -e
+
+function usage {
+  echo "Usage: ${0} ${ARG_DEFS[@]}"
+  exit 1
+}
+
+
+function parseArgs {
+  local REQUIRED_ARG_NAMES=()
+
+  # -- helper functions
+  function varName {
+    # everything to upper case and dash to underscore
+    echo ${1//-/_} | tr '[:lower:]' '[:upper:]'
+  }
+
+  function readArgDefs {
+    local ARG_DEF
+    local AD_OPTIONAL
+    local AD_NAME
+    local AD_RE
+
+    # -- helper functions
+    function parseArgDef {
+      local ARG_DEF_REGEX="(\[?)--([^=]+)=(.*)"
+      if [[ ! $1 =~ $ARG_DEF_REGEX ]]; then
+        echo "Internal error: arg def has wrong format: $ARG_DEF"
+        exit 1
+      fi
+      AD_OPTIONAL="${BASH_REMATCH[1]}"
+      AD_NAME="${BASH_REMATCH[2]}"
+      AD_RE="${BASH_REMATCH[3]}"
+      if [[ $AD_OPTIONAL ]]; then
+        # Remove last bracket for optional args.
+        # Can't put this into the ARG_DEF_REGEX somehow...
+        AD_RE=${AD_RE%?}
+      fi
+    }
+
+    # -- run
+    for ARG_DEF in "${ARG_DEFS[@]}"
+    do
+      parseArgDef $ARG_DEF
+
+      local AD_NAME_UPPER=$(varName $AD_NAME)
+      setVar "${AD_NAME_UPPER}_OPTIONAL" "$AD_OPTIONAL"
+      setVar "${AD_NAME_UPPER}_RE" "$AD_RE"
+      if [[ ! $AD_OPTIONAL ]]; then
+        REQUIRED_ARG_NAMES+=($AD_NAME)
+      fi
+    done
+  }
+
+  function readAndValidateArgs {
+    local ARG_NAME
+    local ARG_VALUE
+    local ARG_NAME_UPPER
+
+    # -- helper functions
+    function parseArg {
+      local ARG_REGEX="--([^=]+)=?(.*)"
+
+      if [[ ! $1 =~ $ARG_REGEX ]]; then
+        echo "Can't parse argument $i"
+        usage
+      fi
+
+      ARG_NAME="${BASH_REMATCH[1]}"
+      ARG_VALUE="${BASH_REMATCH[2]}"
+      ARG_NAME_UPPER=$(varName $ARG_NAME)
+    }
+
+    function validateArg {
+      local AD_RE=$(getVar ${ARG_NAME_UPPER}_RE)
+
+      if [[ ! $AD_RE ]]; then
+        echo "Unknown option: $ARG_NAME"
+        usage
+      fi
+
+      if [[ ! $ARG_VALUE =~ ^${AD_RE}$ ]]; then
+        echo "Wrong format: $ARG_NAME"
+        usage;
+      fi
+
+      # validate that the "action" option points to a valid function
+      if [[ $ARG_NAME == "action" ]] && ! isFunction $ARG_VALUE; then
+        echo "No action $ARG_VALUE defined in this script"
+        usage;
+      fi
+    }
+
+    # -- run
+    for i in "$@"
+    do
+      parseArg $i
+      validateArg
+      setVar "${ARG_NAME_UPPER}" "$ARG_VALUE"
+    done
+  }
+
+  function checkMissingArgs {
+    local ARG_NAME
+    for ARG_NAME in "${REQUIRED_ARG_NAMES[@]}"
+    do
+      ARG_VALUE=$(getVar $(varName $ARG_NAME))
+
+      if [[ ! $ARG_VALUE ]]; then
+        echo "Missing: $ARG_NAME"
+        usage;
+      fi
+    done
+  }
+
+  # -- run
+  readArgDefs
+  readAndValidateArgs "$@"
+  checkMissingArgs
+
+}
+
+# getVar(varName)
+function getVar {
+  echo ${!1}
+}
+
+# setVar(varName, varValue)
+function setVar {
+  eval "$1=\"$2\""
+}
+
+# isFunction(name)
+# - to be used in an if, so return 0 if successful and 1 if not!
+function isFunction {
+  if [[ $(type -t $1) == "function" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# readJsonProp(jsonFile, property)
+# - restriction: property needs to be on an own line!
+function readJsonProp {
+  echo $(sed -En 's/.*"'$2'"[ ]*:[ ]*"(.*)".*/\1/p' $1)
+}
+
+# replaceJsonProp(jsonFile, property, newValue)
+# - note: propertyRegex will be automatically placed into a
+#   capturing group! -> all other groups start at index 2!
+function replaceJsonProp {
+  replaceInFile $1 "\"$2\": \".*?\"" "\"$2\": \"$3\""
+}
+
+# replaceInFile(file, findPattern, replacePattern)
+function replaceInFile {
+  perl -pi -e "s/$2/$3/g;" $1
+}
+
+# resolveDir(relativeDir)
+# - resolves a directory relative to the current script
+function resolveDir {
+  echo $(cd $SCRIPT_DIR; cd $1; pwd)
+}
+
+function git_push_dryrun_proxy {
+  echo "## git push dryrun proxy enabled!"
+  export ORIGIN_GIT=$(which git)
+
+  function git {
+	  local ARGS=("$@")
+	  local RC
+	  if [[ $1 == "push" ]]; then
+	    ARGS+=("--dry-run" "--porcelain")
+	    echo "####### START GIT PUSH DRYRUN #######"
+      echo "${ARGS[@]}"
+	  fi
+	  if [[ $1 == "commit" ]]; then
+      echo "${ARGS[@]}"
+	  fi
+	  $ORIGIN_GIT "${ARGS[@]}"
+	  RC=$?
+	  if [[ $1 == "push" ]]; then
+	    echo "####### END GIT PUSH DRYRUN #######"
+	  fi
+	  return $RC
+  }
+
+  export -f git
+}
+
+function main {
+  # normalize the working dir to the directory of the script
+  cd $(dirname $0);SCRIPT_DIR=$(pwd)
+
+  ARG_DEFS+=("[--git-push-dryrun=(true|false)]" "[--verbose=(true|false)]")
+  parseArgs "$@"
+
+  # --git_push_dryrun argument
+  #if [[ $GIT_PUSH_DRYRUN == "true" ]]; then
+  if [[ $GIT_PUSH_DRYRUN != "false" ]]; then
+    git_push_dryrun_proxy
+  fi
+
+  # --verbose argument
+  #if [[ $VERBOSE = "true" ]]; then
+  if [[ $VERBOSE = "true" ]]; then
+    set -x
+  fi
+
+  if isFunction init; then
+    init "$@"
+  fi
+
+  # jump to the function denoted by the --action argument,
+  # otherwise call the "run" function
+  if [[ $ACTION ]]; then
+    $ACTION "$@"
+  else
+    run "$@"
+  fi
+}
+
+
+main "$@"

--- a/tsd.json
+++ b/tsd.json
@@ -103,6 +103,12 @@
     },
     "source-map/source-map.d.ts": {
       "commit": "5d0f2126c8dac8fce0ff020218aea06607213b0d"
+    },
+    "colors/colors.d.ts": {
+      "commit": "bcd5761826eb567876c197ccc6a87c4d05731054"
+    },
+    "tmp/tmp.d.ts": {
+      "commit": "bcd5761826eb567876c197ccc6a87c4d05731054"
     }
   }
 }


### PR DESCRIPTION
Added script (`scripts/update-pkg-versions.sh`) to assist in the release process. Running this script compiles new versions of the library & tags the current repo with the version specified in the `package.json`. It also clones the **package-ngofficeuifabric** repo & updates it accordingly with the current library version, dependencies & changelog, then tags & pushes it to it's remote. See the comments in the header of the script for more details on usage and more docs.

References #9.
