### PR TITLE
Fixed issue where failed vet tasks wouldn't emit error breaking build

### DIFF
--- a/build/global.d.ts
+++ b/build/global.d.ts
@@ -24,18 +24,23 @@ interface IStringCallback {
  * @typedef commandLineArgs
  * @type {Object}
  * @property {boolean}  debug     - Flag if Node process should start in debug mode.
+ * @property {boolean}  dev       - Flag indicating if development package should be created (unminified, with comments and sourcemaps)
+ * @property {boolean}  file      - Name of the file changed (used in 'gulp test' to filter tests)
+ * @property {boolean}  noExit    - Flag indicating if errors should not be emitted and thus terminating process.
+ * @property {boolean}  serve     - Flag to auto reload connected browsers when sources for demo changed.
  * @property {boolean}  specs     - Flag indicating if the tests should be written to the console.
  * @property {boolean}  verbose   - Flag if tasks should output verbose messages to console.
  * @property {number}   version   - Version number to use in building library, overriding what's in package.json.
- * @property {boolean}  dev       - Flag indicating if development package should be created (unminified, with comments and sourcemaps)
+ * @property {boolean}  watch     -
  */
 interface ICommandLineArgs {
   debug?: boolean;
+  dev?: boolean;
+  file?: string;
+  noExit?: boolean;
+  serve?: boolean;
   specs?: boolean;
   verbose?: boolean;
   version?: number;
-  dev?: boolean;
   watch?: boolean;
-  serve?: boolean;
-  file?: string;
 }

--- a/build/gulp/tasks/test.ts
+++ b/build/gulp/tasks/test.ts
@@ -35,6 +35,7 @@ export class GulpTask extends BaseGulpTask {
    */
   public static options: any = {
     'debug': 'Set karma log level to DEBUG',
+    'file': 'Changed file to filter tests down to just that file',
     'specs': 'Output all tests being run',
     'verbose': 'Output all TypeScript files being built & set karma log level to INFO',
     'watch': 'Adds Chrome browser and start listening on file changes for easier debugging'

--- a/build/gulp/tasks/validate-build.ts
+++ b/build/gulp/tasks/validate-build.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import {BaseGulpTask} from '../BaseGulpTask';
+import {Utils} from '../utils';
 import * as gulp from 'gulp';
 import * as runSequence from 'run-sequence';
 
@@ -45,6 +46,9 @@ export class GulpTask extends BaseGulpTask {
   constructor(cb: gulp.TaskCallback) {
     super();
 
-    runSequence('vet', 'test', 'build-lib', cb);
+    Utils.spawnGulpTask('vet', '--noExit')
+      .on('exit', () => {
+        runSequence('test', 'build-lib', cb);
+      });
   }
 }

--- a/build/gulp/tasks/vet-build-ts.ts
+++ b/build/gulp/tasks/vet-build-ts.ts
@@ -24,6 +24,7 @@ export class GulpTask extends BaseGulpTask {
    * @property  {Object}  options   - Any command line flags that can be passed to the task.
    */
   public static options: any = {
+    'noExit': 'Flag if failed vetting should not emit error this terminating the process',
     'verbose': 'Output all TypeScript files being vetted'
   };
 
@@ -36,14 +37,13 @@ export class GulpTask extends BaseGulpTask {
   constructor(done: IVoidCallback) {
     super();
     Utils.log('Vetting build TypeScript code');
-
     return gulp.src(BuildConfig.BUILD_TYPESCRIPT)
       .pipe($.if(this._args.verbose, $.print()))
       .pipe($.tslint({
         configuration: BuildConfig.ROOT + '/tslint.json'
       }))
       .pipe($.tslint.report('verbose', {
-        emitError: false,
+        emitError: this._args.noExit ? false : true,
         summarizeFailureOutput: true
       }));
   }

--- a/build/gulp/tasks/vet-lib-ts.ts
+++ b/build/gulp/tasks/vet-lib-ts.ts
@@ -23,6 +23,7 @@ export class GulpTask extends BaseGulpTask {
    * @property  {Object}  options   - Any command line flags that can be passed to the task.
    */
   public static options: any = {
+    'noExit': 'Flag if failed vetting should not emit error this terminating the process',
     'verbose': 'Output all TypeScript files being vetted'
   };
 
@@ -44,7 +45,7 @@ export class GulpTask extends BaseGulpTask {
         configuration: BuildConfig.ROOT + '/tslint.json'
       }))
       .pipe($.tslint.report('verbose', {
-        emitError: false,
+        emitError: this._args.noExit ? false : true,
         summarizeFailureOutput: true
       }));
   }

--- a/build/gulp/tasks/vet.ts
+++ b/build/gulp/tasks/vet.ts
@@ -29,6 +29,7 @@ export class GulpTask extends BaseGulpTask {
    * @property  {Object}  options   - Any command line flags that can be passed to the task.
    */
   public static options: any = {
+    'noExit': 'Flag if failed vetting should not emit error this terminating the process',
     'verbose': 'Output all TypeScript files being vetted'
   };
 

--- a/build/gulp/utils.ts
+++ b/build/gulp/utils.ts
@@ -1,13 +1,14 @@
 'use strict';
 
 import * as events from 'events';
+import * as childProcess from 'child_process';
 let $: any = require('gulp-load-plugins')({ lazy: true });
 
 export class Utils {
   /**
    * Log a message or series of messages using chalk's blue color.
    * Can pass in a string, object or array.
-   * 
+   *
    * @param {(string|string[]} message - Message(s) to write to the log.
    */
   public static log(message: string | string[]): void {
@@ -24,7 +25,7 @@ export class Utils {
 
   /**
    * Logs any errors that are passed in & publishes the 'end' event.
-   * 
+   *
    * @param {Object}  error   - Error object to log.
    */
   public static handleError(error: IGulpError): void {
@@ -35,4 +36,25 @@ export class Utils {
     let eventEmitter: NodeJS.EventEmitter = new events.EventEmitter();
     eventEmitter.emit('end');
   }
+
+  /**
+   * Spawns a child gulp task with additional command line arguments which run-sequence does not support.
+   *
+   * @param  {string} task                - Gulp task to run.
+   * @param  {string[]} ...taskArgs - Arguments passed to gulp task.
+   */
+  public static spawnGulpTask: (task: string, ...taskArgs: string[]) => childProcess.ChildProcess =
+  (task: string, ...taskArgs: string[]) => {
+    let isWindows: boolean = (process.platform.lastIndexOf('win') === 0);
+
+    let command: string = isWindows ? 'cmd.exe' : 'sh';
+    let args: string = ['gulp ' + task].concat(process.argv.slice(3)).concat(taskArgs).join(' ');
+
+    if (isWindows) {
+      return childProcess.spawn(command, ['/c', args], { env: process.env, stdio: 'inherit' });
+    }
+
+    return childProcess.spawn(command, ['-c', args], { env: process.env, stdio: 'inherit' });
+  };
+
 }


### PR DESCRIPTION
Addresses issue when a failed vet would not emit an error and thus, break the build. New optional parameter `--noExit` tells the vet tasks to not emit an error. By default they do emit errors again, but when running the `live-dev` task, it swallows the error code and just writes the error message.

Look at full commit message on https://github.com/ngOfficeUIFabric/ng-officeuifabric/commit/79e08db7b2eb4a64b1db5378cddfc84bf50f2ba0 for full details.

Closes #192.
