### PR TITLE
fix(callout): close button type set to "button"

### DIFF
--- a/src/components/callout/calloutDirective.spec.ts
+++ b/src/components/callout/calloutDirective.spec.ts
@@ -205,6 +205,7 @@ describe('calloutDirectives:', () => {
         let closeButton: JQuery = calloutElement.find('button.ms-Callout-close').eq(0);
         expect(closeButton).toBeDefined();
         expect(closeButton).not.toBeNull();
+        expect(closeButton).toHaveAttr('type', 'button');
 
         let buttonIcon: JQuery = closeButton.find('i').eq(0);
         expect(buttonIcon[0]).toHaveClass('ms-Icon');

--- a/src/components/callout/calloutDirective.ts
+++ b/src/components/callout/calloutDirective.ts
@@ -270,7 +270,7 @@ export class CalloutDirective implements ng.IDirective {
       scope.closeButton = true;
 
       let closeButtonElement: ng.IAugmentedJQuery = ng.element(
-        '<button class="ms-Callout-close">' +
+        '<button class="ms-Callout-close" type="button">' +
         '<i class="ms-Icon ms-Icon--x"></i>' +
         '</button>');
 


### PR DESCRIPTION
Added type attribute to the close button to prevent the button from triggering form submission if callout would be placed inside form.

Closes #221.
