### PR TITLE
fix(textfield): fixed placeholder to hide when textfield gets focus

### DIFF
--- a/src/components/textfield/textFieldDirective.spec.ts
+++ b/src/components/textfield/textFieldDirective.spec.ts
@@ -108,6 +108,9 @@ describe('textFieldDirective: <uif-textfield />', () => {
         input.blur();
         expect(label.hasClass('ng-hide')).toBe(false, 'Label should be visible after blur');
 
+        input.focus();
+        expect(label.hasClass('ng-hide')).toBe(true, 'Label should be hidden after focus');
+
         $scope.value = 'Test';
         $scope.$apply();
 

--- a/src/components/textfield/textFieldDirective.spec.ts
+++ b/src/components/textfield/textFieldDirective.spec.ts
@@ -102,14 +102,11 @@ describe('textFieldDirective: <uif-textfield />', () => {
         expect(label.hasClass('ng-hide')).toBe(false, 'Label should be visible before click');
 
         let input: JQuery = textBox.find('input');
-        input.click();
-        expect(label.hasClass('ng-hide')).toBe(true, 'Label should be hidden after click');
+        input.focus();
+        expect(label.hasClass('ng-hide')).toBe(true, 'Label should be hidden after focus');
 
         input.blur();
         expect(label.hasClass('ng-hide')).toBe(false, 'Label should be visible after blur');
-
-        input.focus();
-        expect(label.hasClass('ng-hide')).toBe(true, 'Label should be hidden after focus');
 
         $scope.value = 'Test';
         $scope.$apply();

--- a/src/components/textfield/textFieldDirective.ts
+++ b/src/components/textfield/textFieldDirective.ts
@@ -86,7 +86,6 @@ export class TextFieldDirective implements ng.IDirective {
             if (scope.placeholder) {
                 scope.labelShown = false;
             }
-                        
             if (scope.uifUnderlined) {
                 scope.isActive = true;
             }

--- a/src/components/textfield/textFieldDirective.ts
+++ b/src/components/textfield/textFieldDirective.ts
@@ -83,6 +83,10 @@ export class TextFieldDirective implements ng.IDirective {
         scope.disabled = 'disabled' in attrs;
         scope.uifUnderlined = 'uifUnderlined' in attrs;
         scope.inputFocus = function(ev: any): void {
+            if (scope.placeholder) {
+                scope.labelShown = false;
+            }
+                        
             if (scope.uifUnderlined) {
                 scope.isActive = true;
             }

--- a/src/components/textfield/textFieldDirective.ts
+++ b/src/components/textfield/textFieldDirective.ts
@@ -26,7 +26,6 @@ export interface ITextFieldScope extends ng.IScope {
     labelShown: boolean;
     uifUnderlined: boolean;
     inputFocus: (ev: any) => void;
-    inputClick: (ev: any) => void;
     inputBlur: (ev: any) => void;
     isActive: boolean;
     required: boolean;
@@ -88,11 +87,6 @@ export class TextFieldDirective implements ng.IDirective {
             }
             if (scope.uifUnderlined) {
                 scope.isActive = true;
-            }
-        };
-        scope.inputClick = function(ev: any): void {
-            if (scope.placeholder) {
-                scope.labelShown = false;
             }
         };
         scope.inputBlur = function (ev: any): void {


### PR DESCRIPTION
fix(textfield): fixed placeholder to hide when textfield gets focus (e.g. tab between fields)

This is also a bug in the Office UI Fabric.  I submitted a PR to fix which I believe will be accepted.
https://github.com/OfficeDev/Office-UI-Fabric/pull/491
