### PR TITLE
refactor(table): changed rendering to use table markup closing #294

### DIFF
--- a/src/components/table/demo/index.html
+++ b/src/components/table/demo/index.html
@@ -24,20 +24,24 @@
     This markup: <br />
     <pre>
 &lt;uif-table&gt;
-    &lt;uif-table-row&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-header&gt;File name&lt;/uif-table-header&gt;
-        &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
-        &lt;uif-table-header&gt;Modified&lt;/uif-table-header&gt;
-        &lt;uif-table-header&gt;Type&lt;/uif-table-header&gt;
-    &lt;/uif-table-row&gt;
-    &lt;uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}<!---->}"&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
-    &lt;/uif-table-row&gt;
+    &lt;uif-table-head&gt;
+        &lt;uif-table-row&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-header&gt;File name&lt;/uif-table-header&gt;
+            &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
+            &lt;uif-table-header&gt;Modified&lt;/uif-table-header&gt;
+            &lt;uif-table-header&gt;Type&lt;/uif-table-header&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-head&gt;
+    &lt;uif-table-body&gt;
+        &lt;uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}<!---->}"&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-body&gt;
 &lt;/uif-table&gt;
     </pre>
   </p>
@@ -46,27 +50,25 @@
     Renders this:
     <br />
         <uif-table>
-            <uif-table-row>
-                <uif-table-row-select></uif-table-row-select>
-                <uif-table-header>File name</uif-table-header>
-                <uif-table-header>Location</uif-table-header>
-                <uif-table-header>Modified</uif-table-header>
-                <uif-table-header>Type</uif-table-header>
-            </uif-table-row>
-            <uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}}">
-                <uif-table-row-select></uif-table-row-select>
-                <uif-table-cell>{{f.fileName}}</uif-table-cell>
-                <uif-table-cell>{{f.location}}</uif-table-cell>
-                <uif-table-cell>{{f.modified | date}}</uif-table-cell>
-                <uif-table-cell>{{f.type}}</uif-table-cell>
-            </uif-table-row>
+            <uif-table-head>
+                <uif-table-row>
+                    <uif-table-row-select></uif-table-row-select>
+                    <uif-table-header>File name</uif-table-header>
+                    <uif-table-header>Location</uif-table-header>
+                    <uif-table-header>Modified</uif-table-header>
+                    <uif-table-header>Type</uif-table-header>
+                </uif-table-row>
+            </uif-table-head>
+            <uif-table-body>
+                <uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}}">
+                    <uif-table-row-select></uif-table-row-select>
+                    <uif-table-cell>{{f.fileName}}</uif-table-cell>
+                    <uif-table-cell>{{f.location}}</uif-table-cell>
+                    <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+                    <uif-table-cell>{{f.type}}</uif-table-cell>
+                </uif-table-row>
+            </uif-table-body>
         </uif-table>
-  </p>
-  
-  <h2>Selecting rows</h2>
-  <p>
-      The <code>&lt;uif-table-row-select&gt;</code> directive renders a control that can be used to select and unselect rows.
-      Although the directive is already present, support for selecting rows will be added in the future.
   </p>
   
   <h2>Marking rows as selected</h2>
@@ -92,22 +94,26 @@
     This markup: <br />
     <pre>
 &lt;uif-table&gt;
-    &lt;uif-table-row&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
-        &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
-    &lt;/uif-table-row&gt;
-    &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-selected="{{f.isSelected}<!---->}"&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
-    &lt;/uif-table-row&gt;
+    &lt;uif-table-head&gt;
+        &lt;uif-table-row&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
+            &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-head&gt;
+    &lt;uif-table-body&gt;
+        &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-selected="{{f.isSelected}<!---->}"&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-body&gt;
 &lt;/uif-table&gt;
     </pre>
   </p>
@@ -115,22 +121,26 @@
     Renders this (<em>please note that sorting hasn't been enabled for the <strong>Location</strong> column</em>):
     <br />
         <uif-table>
-            <uif-table-row>
-                <uif-table-row-select></uif-table-row-select>
-                <uif-table-header uif-order-by="fileName">File name</uif-table-header>
-                <uif-table-header>Location</uif-table-header>
-                <uif-table-header uif-order-by="modified">Modified</uif-table-header>
-                <uif-table-header uif-order-by="type">Type</uif-table-header>
-                <uif-table-header uif-order-by="size">Size</uif-table-header>
-            </uif-table-row>
-            <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-selected="{{f.isSelected}}">
-                <uif-table-row-select></uif-table-row-select>
-                <uif-table-cell>{{f.fileName}}</uif-table-cell>
-                <uif-table-cell>{{f.location}}</uif-table-cell>
-                <uif-table-cell>{{f.modified | date}}</uif-table-cell>
-                <uif-table-cell>{{f.type}}</uif-table-cell>
-                <uif-table-cell>{{f.size}}</uif-table-cell>
-            </uif-table-row>
+            <uif-table-head>
+                <uif-table-row>
+                    <uif-table-row-select></uif-table-row-select>
+                    <uif-table-header uif-order-by="fileName">File name</uif-table-header>
+                    <uif-table-header>Location</uif-table-header>
+                    <uif-table-header uif-order-by="modified">Modified</uif-table-header>
+                    <uif-table-header uif-order-by="type">Type</uif-table-header>
+                    <uif-table-header uif-order-by="size">Size</uif-table-header>
+                </uif-table-row>
+            </uif-table-head>
+            <uif-table-body>
+                <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-selected="{{f.isSelected}}">
+                    <uif-table-row-select></uif-table-row-select>
+                    <uif-table-cell>{{f.fileName}}</uif-table-cell>
+                    <uif-table-cell>{{f.location}}</uif-table-cell>
+                    <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+                    <uif-table-cell>{{f.type}}</uif-table-cell>
+                    <uif-table-cell>{{f.size}}</uif-table-cell>
+                </uif-table-row>
+            </uif-table-body>
         </uif-table>
   </p>
   
@@ -157,22 +167,26 @@
     This markup: <br />
     <pre>
 &lt;uif-table uif-row-select-mode="none"&gt;
-    &lt;uif-table-row&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
-        &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
-    &lt;/uif-table-row&gt;
-    &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}<!---->}"&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
-    &lt;/uif-table-row&gt;
+    &lt;uif-table-head&gt;
+        &lt;uif-table-row&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
+            &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-head&gt;
+    &lt;uif-table-body&gt;
+        &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}<!---->}"&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-body&gt;
 &lt;/uif-table&gt;
     </pre>
   </p>
@@ -180,22 +194,26 @@
     Renders this (selecting rows disabled, one row marked as selected):
     <br />
     <uif-table uif-row-select-mode="none">
-        <uif-table-row>
-            <uif-table-row-select></uif-table-row-select>
-            <uif-table-header uif-order-by="fileName">File name</uif-table-header>
-            <uif-table-header>Location</uif-table-header>
-            <uif-table-header uif-order-by="modified">Modified</uif-table-header>
-            <uif-table-header uif-order-by="type">Type</uif-table-header>
-            <uif-table-header uif-order-by="size">Size</uif-table-header>
-        </uif-table-row>
-        <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}}">
-            <uif-table-row-select></uif-table-row-select>
-            <uif-table-cell>{{f.fileName}}</uif-table-cell>
-            <uif-table-cell>{{f.location}}</uif-table-cell>
-            <uif-table-cell>{{f.modified | date}}</uif-table-cell>
-            <uif-table-cell>{{f.type}}</uif-table-cell>
-            <uif-table-cell>{{f.size}}</uif-table-cell>
-        </uif-table-row>
+        <uif-table-head>
+            <uif-table-row>
+                <uif-table-row-select></uif-table-row-select>
+                <uif-table-header uif-order-by="fileName">File name</uif-table-header>
+                <uif-table-header>Location</uif-table-header>
+                <uif-table-header uif-order-by="modified">Modified</uif-table-header>
+                <uif-table-header uif-order-by="type">Type</uif-table-header>
+                <uif-table-header uif-order-by="size">Size</uif-table-header>
+            </uif-table-row>
+        </uif-table-head>
+        <uif-table-body>
+            <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}}">
+                <uif-table-row-select></uif-table-row-select>
+                <uif-table-cell>{{f.fileName}}</uif-table-cell>
+                <uif-table-cell>{{f.location}}</uif-table-cell>
+                <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+                <uif-table-cell>{{f.type}}</uif-table-cell>
+                <uif-table-cell>{{f.size}}</uif-table-cell>
+            </uif-table-row>
+        </uif-table-body>
     </uif-table>
   </p>
   <h3>Selecting single row (<code>&lt;uif-table uif-row-select-mode="single"&gt;</code>)</h3>
@@ -203,22 +221,26 @@
     This markup: <br />
     <pre>
 &lt;uif-table uif-row-select-mode="single"&gt;
-    &lt;uif-table-row&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
-        &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
-    &lt;/uif-table-row&gt;
-    &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}<!---->}"&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
-    &lt;/uif-table-row&gt;
+    &lt;uif-table-head&gt;
+        &lt;uif-table-row&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
+            &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-head&gt;
+    &lt;uif-table-body&gt;
+        &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}<!---->}"&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-body&gt;
 &lt;/uif-table&gt;
     </pre>
   </p>
@@ -226,22 +248,26 @@
     Renders this (selecting single row enabled, one row marked as selected):
     <br />
     <uif-table uif-row-select-mode="single">
-        <uif-table-row>
-            <uif-table-row-select></uif-table-row-select>
-            <uif-table-header uif-order-by="fileName">File name</uif-table-header>
-            <uif-table-header>Location</uif-table-header>
-            <uif-table-header uif-order-by="modified">Modified</uif-table-header>
-            <uif-table-header uif-order-by="type">Type</uif-table-header>
-            <uif-table-header uif-order-by="size">Size</uif-table-header>
-        </uif-table-row>
-        <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}}">
-            <uif-table-row-select></uif-table-row-select>
-            <uif-table-cell>{{f.fileName}}</uif-table-cell>
-            <uif-table-cell>{{f.location}}</uif-table-cell>
-            <uif-table-cell>{{f.modified | date}}</uif-table-cell>
-            <uif-table-cell>{{f.type}}</uif-table-cell>
-            <uif-table-cell>{{f.size}}</uif-table-cell>
-        </uif-table-row>
+        <uif-table-head>
+            <uif-table-row>
+                <uif-table-row-select></uif-table-row-select>
+                <uif-table-header uif-order-by="fileName">File name</uif-table-header>
+                <uif-table-header>Location</uif-table-header>
+                <uif-table-header uif-order-by="modified">Modified</uif-table-header>
+                <uif-table-header uif-order-by="type">Type</uif-table-header>
+                <uif-table-header uif-order-by="size">Size</uif-table-header>
+            </uif-table-row>
+        </uif-table-head>
+        <uif-table-body>
+            <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}}">
+                <uif-table-row-select></uif-table-row-select>
+                <uif-table-cell>{{f.fileName}}</uif-table-cell>
+                <uif-table-cell>{{f.location}}</uif-table-cell>
+                <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+                <uif-table-cell>{{f.type}}</uif-table-cell>
+                <uif-table-cell>{{f.size}}</uif-table-cell>
+            </uif-table-row>
+        </uif-table-body>
     </uif-table>
   </p>
   <h3>Selecting multiple rows (<code>&lt;uif-table uif-row-select-mode="multiple"&gt;</code>)</h3>
@@ -252,22 +278,26 @@
     This markup: <br />
     <pre>
 &lt;uif-table uif-row-select-mode="multiple"&gt;
-    &lt;uif-table-row&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
-        &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
-        &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
-    &lt;/uif-table-row&gt;
-    &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}<!---->}"&gt;
-        &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
-        &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
-        &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
-    &lt;/uif-table-row&gt;
+    &lt;uif-table-head&gt;
+        &lt;uif-table-row&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
+            &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-head&gt;
+    &lt;uif-table-body&gt;
+        &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}<!---->}"&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-body&gt;
 &lt;/uif-table&gt;
     </pre>
   </p>
@@ -275,22 +305,26 @@
     Renders this (selecting multiple rows enabled, one row marked as selected):
     <br />
     <uif-table uif-row-select-mode="multiple">
-        <uif-table-row>
-            <uif-table-row-select></uif-table-row-select>
-            <uif-table-header uif-order-by="fileName">File name</uif-table-header>
-            <uif-table-header>Location</uif-table-header>
-            <uif-table-header uif-order-by="modified">Modified</uif-table-header>
-            <uif-table-header uif-order-by="type">Type</uif-table-header>
-            <uif-table-header uif-order-by="size">Size</uif-table-header>
-        </uif-table-row>
-        <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}}">
-            <uif-table-row-select></uif-table-row-select>
-            <uif-table-cell>{{f.fileName}}</uif-table-cell>
-            <uif-table-cell>{{f.location}}</uif-table-cell>
-            <uif-table-cell>{{f.modified | date}}</uif-table-cell>
-            <uif-table-cell>{{f.type}}</uif-table-cell>
-            <uif-table-cell>{{f.size}}</uif-table-cell>
-        </uif-table-row>
+        <uif-table-head>
+            <uif-table-row>
+                <uif-table-row-select></uif-table-row-select>
+                <uif-table-header uif-order-by="fileName">File name</uif-table-header>
+                <uif-table-header>Location</uif-table-header>
+                <uif-table-header uif-order-by="modified">Modified</uif-table-header>
+                <uif-table-header uif-order-by="type">Type</uif-table-header>
+                <uif-table-header uif-order-by="size">Size</uif-table-header>
+            </uif-table-row>
+        </uif-table-head>
+        <uif-table-body>
+            <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}}">
+                <uif-table-row-select></uif-table-row-select>
+                <uif-table-cell>{{f.fileName}}</uif-table-cell>
+                <uif-table-cell>{{f.location}}</uif-table-cell>
+                <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+                <uif-table-cell>{{f.type}}</uif-table-cell>
+                <uif-table-cell>{{f.size}}</uif-table-cell>
+            </uif-table-row>
+        </uif-table-head>
     </uif-table>
   </p>
 </body>

--- a/src/components/table/demoBasicUsage/index.html
+++ b/src/components/table/demoBasicUsage/index.html
@@ -1,16 +1,20 @@
 <uif-table>
-    <uif-table-row>
-        <uif-table-row-select></uif-table-row-select>
-        <uif-table-header>File name</uif-table-header>
-        <uif-table-header>Location</uif-table-header>
-        <uif-table-header>Modified</uif-table-header>
-        <uif-table-header>Type</uif-table-header>
-    </uif-table-row>
-    <uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}}">
-        <uif-table-row-select></uif-table-row-select>
-        <uif-table-cell>{{f.fileName}}</uif-table-cell>
-        <uif-table-cell>{{f.location}}</uif-table-cell>
-        <uif-table-cell>{{f.modified | date}}</uif-table-cell>
-        <uif-table-cell>{{f.type}}</uif-table-cell>
-    </uif-table-row>
+    <uif-table-head>
+        <uif-table-row>
+            <uif-table-row-select></uif-table-row-select>
+            <uif-table-header>File name</uif-table-header>
+            <uif-table-header>Location</uif-table-header>
+            <uif-table-header>Modified</uif-table-header>
+            <uif-table-header>Type</uif-table-header>
+        </uif-table-row>
+    </uif-table-head>
+    <uif-table-body>
+        <uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}}">
+            <uif-table-row-select></uif-table-row-select>
+            <uif-table-cell>{{f.fileName}}</uif-table-cell>
+            <uif-table-cell>{{f.location}}</uif-table-cell>
+            <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+            <uif-table-cell>{{f.type}}</uif-table-cell>
+        </uif-table-row>
+    </uif-table-body>
 </uif-table>

--- a/src/components/table/demoSortableColumns/index.html
+++ b/src/components/table/demoSortableColumns/index.html
@@ -1,18 +1,22 @@
 <uif-table>
-    <uif-table-row>
-        <uif-table-row-select></uif-table-row-select>
-        <uif-table-header uif-order-by="fileName">File name</uif-table-header>
-        <uif-table-header>Location</uif-table-header>
-        <uif-table-header uif-order-by="modified">Modified</uif-table-header>
-        <uif-table-header uif-order-by="type">Type</uif-table-header>
-        <uif-table-header uif-order-by="size">Size</uif-table-header>
-    </uif-table-row>
-    <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-selected="{{f.isSelected}}">
-        <uif-table-row-select></uif-table-row-select>
-        <uif-table-cell>{{f.fileName}}</uif-table-cell>
-        <uif-table-cell>{{f.location}}</uif-table-cell>
-        <uif-table-cell>{{f.modified | date}}</uif-table-cell>
-        <uif-table-cell>{{f.type}}</uif-table-cell>
-        <uif-table-cell>{{f.size}}</uif-table-cell>
-    </uif-table-row>
+    <uif-table-head>
+        <uif-table-row>
+            <uif-table-row-select></uif-table-row-select>
+            <uif-table-header uif-order-by="fileName">File name</uif-table-header>
+            <uif-table-header>Location</uif-table-header>
+            <uif-table-header uif-order-by="modified">Modified</uif-table-header>
+            <uif-table-header uif-order-by="type">Type</uif-table-header>
+            <uif-table-header uif-order-by="size">Size</uif-table-header>
+        </uif-table-row>
+    </uif-table-head>
+    <uif-table-body>
+        <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-selected="{{f.isSelected}}">
+            <uif-table-row-select></uif-table-row-select>
+            <uif-table-cell>{{f.fileName}}</uif-table-cell>
+            <uif-table-cell>{{f.location}}</uif-table-cell>
+            <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+            <uif-table-cell>{{f.type}}</uif-table-cell>
+            <uif-table-cell>{{f.size}}</uif-table-cell>
+        </uif-table-row>
+    </uif-table-body>
 </uif-table>

--- a/src/components/table/tableDirective.spec.ts
+++ b/src/components/table/tableDirective.spec.ts
@@ -15,11 +15,11 @@ describe('tableDirective: <uif-table />', () => {
         scope = $rootScope;
     }));
 
-    it('should render table using a div tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+    it('should render table using a table tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table></uif-table>');
         $compile(element)(scope);
         scope.$digest();
-        expect(element.prop('tagName')).toEqual('DIV');
+        expect(element.prop('tagName')).toEqual('TABLE');
     }));
 
     it('should set correct Office UI Fabric classes on the table', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
@@ -29,18 +29,18 @@ describe('tableDirective: <uif-table />', () => {
         expect(element).toHaveClass('ms-Table');
     }));
 
-    it('should render the row using a div tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+    it('should render the row using a tr tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table><uif-table-row></uif-table-row></uif-table>');
         $compile(element)(scope);
         scope.$digest();
-        expect(element.children().eq(0).prop('tagName')).toEqual('DIV');
+        expect(element.children().eq(0).prop('tagName')).toEqual('TR');
     }));
 
-    it('should set correct Office UI Fabric classes on the row', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+    it('should set no Office UI Fabric classes on the row', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table><uif-table-row></uif-table-row></uif-table>');
         $compile(element)(scope);
         scope.$digest();
-        expect(element.children().eq(0)).toHaveClass('ms-Table-row');
+        expect(element.children().eq(0)).not.toHaveClass('ms-Table-row');
     }));
 
     it('should set correct Office UI Fabric classes on the selected and unselected rows',
@@ -66,11 +66,37 @@ describe('tableDirective: <uif-table />', () => {
         expect($log.error.logs.length).toEqual(1);
      }));
 
-    it('should render table row select using the span tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+    it('should render table row select using the td tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table><uif-table-row><uif-table-row-select></uif-table-row-select></uif-table-row></uif-table>');
         $compile(element)(scope);
         scope.$digest();
-        expect(element.children().eq(0).children().eq(0).prop('tagName')).toEqual('SPAN');
+        expect(element.children().eq(0).children().eq(0).prop('tagName')).toEqual('TD');
+    }));
+
+    it('should render table row select using the th tag in thead', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        element = ng.element('<uif-table>\
+        <uif-table-head><uif-table-row><uif-table-row-select></uif-table-row-select></uif-table-row></uif-table-head>\
+        <uif-table-body><uif-table-row><uif-table-row-select></uif-table-row-select></uif-table-row></uif-table-body>\
+        </uif-table>');
+        $compile(element)(scope);
+        scope.$digest();
+        expect(element.children().eq(0) // thead
+               .children().eq(0) // tr
+               .children().eq(0) // table-row-select
+               .prop('tagName')).toEqual('TH');
+    }));
+
+    it('should render table row select using the td tag in tbody', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        element = ng.element('<uif-table>\
+        <uif-table-head><uif-table-row><uif-table-row-select></uif-table-row-select></uif-table-row></uif-table-head>\
+        <uif-table-body><uif-table-row><uif-table-row-select></uif-table-row-select></uif-table-row></uif-table-body>\
+        </uif-table>');
+        $compile(element)(scope);
+        scope.$digest();
+        expect(element.children().eq(1) // tbody
+               .children().eq(0) // tr
+               .children().eq(0) // table-row-select
+               .prop('tagName')).toEqual('TD');
     }));
 
     it('should set correct Office UI Fabric classes on the table row select',
@@ -81,32 +107,32 @@ describe('tableDirective: <uif-table />', () => {
         expect(element.children().eq(0).children().eq(0)).toHaveClass('ms-Table-rowCheck');
     }));
 
-    it('should render the cell using a span tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+    it('should render the cell using a td tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table-cell></uif-table-cell>');
         $compile(element)(scope);
         scope.$digest();
-        expect(element.prop('tagName')).toEqual('SPAN');
+        expect(element.prop('tagName')).toEqual('TD');
     }));
 
-    it('should set correct Office UI Fabric classes on the table cell', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+    it('should set no Office UI Fabric classes on the table cell', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table-cell></uif-table-cell>');
         $compile(element)(scope);
         scope.$digest();
-        expect(element).toHaveClass('ms-Table-cell');
+        expect(element).not.toHaveClass('ms-Table-cell');
     }));
 
-    it('should render the table header using a span tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+    it('should render the table header using a th tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table><uif-table-row><uif-table-header></uif-table-header></uif-table-row></uif-table>');
         $compile(element)(scope);
         scope.$digest();
-        expect(element.children().eq(0).children().eq(0).prop('tagName')).toEqual('SPAN');
+        expect(element.children().eq(0).children().eq(0).prop('tagName')).toEqual('TH');
     }));
 
-    it('should set correct Office UI Fabric classes on the table header', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+    it('should set no Office UI Fabric classes on the table header', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table><uif-table-row><uif-table-header></uif-table-header></uif-table-row></uif-table>');
         $compile(element)(scope);
         scope.$digest();
-        expect(element.children().eq(0).children().eq(0)).toHaveClass('ms-Table-cell');
+        expect(element.children().eq(0).children().eq(0)).not.toHaveClass('ms-Table-cell');
     }));
 
     it('should trigger sorting only on enabled header cells', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {

--- a/src/components/table/tableDirective.ts
+++ b/src/components/table/tableDirective.ts
@@ -115,27 +115,31 @@ export interface ITableAttributes extends ng.IAttributes {
  * @usage
  * 
  * <uif-table>
- *   <uif-table-row>
- *     <uif-table-row-select></uif-table-row-select>
- *     <uif-table-header>File name</uif-table-header>
- *     <uif-table-header>Location</uif-table-header>
- *     <uif-table-header>Modified</uif-table-header>
- *     <uif-table-header>Type</uif-table-header>
- *   </uif-table-row>
- *   <uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}}">
- *     <uif-table-row-select></uif-table-row-select>
- *     <uif-table-cell>{{f.fileName}}</uif-table-cell>
- *     <uif-table-cell>{{f.location}}</uif-table-cell>
- *     <uif-table-cell>{{f.modified | date}}</uif-table-cell>
- *     <uif-table-cell>{{f.type}}</uif-table-cell>
- *   </uif-table-row>
+ *   <uif-table-head>
+ *     <uif-table-row>
+ *       <uif-table-row-select></uif-table-row-select>
+ *       <uif-table-header>File name</uif-table-header>
+ *       <uif-table-header>Location</uif-table-header>
+ *       <uif-table-header>Modified</uif-table-header>
+ *       <uif-table-header>Type</uif-table-header>
+ *     </uif-table-row>
+ *   </uif-table-head>
+ *   <uif-table-body>
+ *     <uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}}">
+ *       <uif-table-row-select></uif-table-row-select>
+ *       <uif-table-cell>{{f.fileName}}</uif-table-cell>
+ *       <uif-table-cell>{{f.location}}</uif-table-cell>
+ *       <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+ *       <uif-table-cell>{{f.type}}</uif-table-cell>
+ *     </uif-table-row>
+ *   </uif-table-body>
  * </uif-table>
  */
 export class TableDirective implements ng.IDirective {
     public restrict: string = 'E';
     public transclude: boolean = true;
     public replace: boolean = true;  // required for correct HTML rendering
-    public template: string = '<div class="ms-Table" ng-transclude></div>';
+    public template: string = '<table class="ms-Table" ng-transclude></table>';
     public controller: any = TableController;
     public controllerAs: string = 'table';
 
@@ -245,7 +249,7 @@ export class TableRowDirective implements ng.IDirective {
     public restrict: string = 'E';
     public transclude: boolean = true;
     public replace: boolean = true;  // required for correct HTML rendering    
-    public template: string = '<div class="ms-Table-row" ng-transclude></div>';
+    public template: string = '<tr ng-transclude></tr>';
     public require: string = '^uifTable';
     public scope: {} = {
         item: '=uifItem'
@@ -329,6 +333,7 @@ export class TableRowDirective implements ng.IDirective {
  */
 export interface ITableRowSelectScope extends ng.IScope {
     rowSelectClick: (ev: any) => void;
+    tagName: string;
 }
 
 /**
@@ -355,9 +360,9 @@ export interface ITableRowSelectScope extends ng.IScope {
  */
 export class TableRowSelectDirective implements ng.IDirective {
     public restrict: string = 'E';
-    public template: string = '<span class="ms-Table-rowCheck"></span>';
+    public template: string = '<td class="ms-Table-rowCheck"></td>';
     public replace: boolean = true;  // required for correct HTML rendering
-    public require: string[] = ['^uifTable', '^uifTableRow'];
+    public require: string[] = ['^uifTable', '?^uifTableHead', '^uifTableRow'];
 
     public static factory(): ng.IDirectiveFactory {
         const directive: ng.IDirectiveFactory = () => new TableRowSelectDirective();
@@ -369,9 +374,14 @@ export class TableRowSelectDirective implements ng.IDirective {
                 instanceElement: ng.IAugmentedJQuery,
                 attrs: ng.IAttributes,
                 controllers: any[]): void {
+        let thead: TableHeadController = controllers[1];
+        if (thead) {
+            instanceElement.replaceWith('<th class="ms-Table-rowCheck"></th>');
+        }
+
         scope.rowSelectClick = (ev: any): void => {
             let table: TableController = controllers[0];
-            let row: TableRowController = controllers[1];
+            let row: TableRowController = controllers[2];
 
             if (table.rowSelectMode !== TableRowSelectModeEnum[TableRowSelectModeEnum.multiple]) {
                 return;
@@ -422,7 +432,7 @@ export class TableRowSelectDirective implements ng.IDirective {
 export class TableCellDirective implements ng.IDirective {
     public restrict: string = 'E';
     public transclude: boolean = true;
-    public template: string = '<span class="ms-Table-cell" ng-transclude></span>';
+    public template: string = '<td ng-transclude></td>';
     public replace: boolean = true;  // required for correct HTML rendering    
 
     public static factory(): ng.IDirectiveFactory {
@@ -480,7 +490,7 @@ export class TableHeaderDirective implements ng.IDirective {
     public restrict: string = 'E';
     public transclude: boolean = true;
     public replace: boolean = true; // required for correct HTML rendering
-    public template: string = '<span class="ms-Table-cell" ng-transclude></span>';
+    public template: string = '<th ng-transclude></th>';
     public require: string = '^uifTable';
 
     public static factory(): ng.IDirectiveFactory {
@@ -531,6 +541,76 @@ export class TableHeaderDirective implements ng.IDirective {
     }
 }
 
+class TableHeadController {
+}
+
+/**
+ * @ngdoc directive
+ * @name uifTableHead
+ * @module officeuifabric.components.table
+ * 
+ * @restrict E
+ * 
+ * @description 
+ * `<uif-table-head>` is a table head directive that denotes table head rows.
+ * 
+ * @see {link http://dev.office.com/fabric/components/table}
+ * 
+ * @usage
+ * 
+ * <uif-table>
+ *   <uif-table-head>
+ *     <uif-table-row>...</uif-table-row>
+ *   </uif-table-head>
+ * </uif-table>
+ */
+export class TableHeadDirective implements ng.IDirective {
+    public restrict: string = 'E';
+    public transclude: boolean = true;
+    public template: string = '<thead ng-transclude></thead>';
+    public replace: boolean = true;  // required for correct HTML rendering
+    public controller: any = TableHeadController;
+
+    public static factory(): ng.IDirectiveFactory {
+        const directive: ng.IDirectiveFactory = () => new TableHeadDirective();
+
+        return directive;
+    }
+}
+
+/**
+ * @ngdoc directive
+ * @name uifTableBody
+ * @module officeuifabric.components.table
+ * 
+ * @restrict E
+ * 
+ * @description 
+ * `<uif-table-body>` is a table body directive that denotes table body rows.
+ * 
+ * @see {link http://dev.office.com/fabric/components/table}
+ * 
+ * @usage
+ * 
+ * <uif-table>
+ *   <uif-table-body>
+ *     <uif-table-row>...</uif-table-row>
+ *   </uif-table-body>
+ * </uif-table>
+ */
+export class TableBodyDirective implements ng.IDirective {
+    public restrict: string = 'E';
+    public transclude: boolean = true;
+    public template: string = '<tbody ng-transclude></tbody>';
+    public replace: boolean = true;  // required for correct HTML rendering    
+
+    public static factory(): ng.IDirectiveFactory {
+        const directive: ng.IDirectiveFactory = () => new TableBodyDirective();
+
+        return directive;
+    }
+}
+
 /**
  * @ngdoc module
  * @name officeuifabric.components.table
@@ -543,4 +623,6 @@ export var module: ng.IModule = ng.module('officeuifabric.components.table', ['o
     .directive('uifTableRow', TableRowDirective.factory())
     .directive('uifTableRowSelect', TableRowSelectDirective.factory())
     .directive('uifTableCell', TableCellDirective.factory())
-    .directive('uifTableHeader', TableHeaderDirective.factory());
+    .directive('uifTableHeader', TableHeaderDirective.factory())
+    .directive('uifTableHead', TableHeadDirective.factory())
+    .directive('uifTableBody', TableBodyDirective.factory());


### PR DESCRIPTION
refactor(table): changed rendering to use table markup

BREAKING CHANGE: although the table won't break it's recommended to add the `uif-table-head` and `uif-table-body` directives to the table for accessibility and rendering purposes.

Change your code from:

``` html
<uif-table>
    <uif-table-row>
        <uif-table-row-select></uif-table-row-select>
        <uif-table-header>File name</uif-table-header>
        <uif-table-header>Location</uif-table-header>
        <uif-table-header>Modified</uif-table-header>
        <uif-table-header>Type</uif-table-header>
    </uif-table-row>
    <uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}}">
        <uif-table-row-select></uif-table-row-select>
        <uif-table-cell>{{f.fileName}}</uif-table-cell>
        <uif-table-cell>{{f.location}}</uif-table-cell>
        <uif-table-cell>{{f.modified | date}}</uif-table-cell>
        <uif-table-cell>{{f.type}}</uif-table-cell>
    </uif-table-row>
</uif-table>
```

to:

``` html
<uif-table>
    <uif-table-head>
        <uif-table-row>
            <uif-table-row-select></uif-table-row-select>
            <uif-table-header>File name</uif-table-header>
            <uif-table-header>Location</uif-table-header>
            <uif-table-header>Modified</uif-table-header>
            <uif-table-header>Type</uif-table-header>
        </uif-table-row>
    </uif-table-head>
    <uif-table-body>
        <uif-table-row ng-repeat="f in files" uif-selected="{{f.isSelected}}">
            <uif-table-row-select></uif-table-row-select>
            <uif-table-cell>{{f.fileName}}</uif-table-cell>
            <uif-table-cell>{{f.location}}</uif-table-cell>
            <uif-table-cell>{{f.modified | date}}</uif-table-cell>
            <uif-table-cell>{{f.type}}</uif-table-cell>
        </uif-table-row>
    </uif-table-body>
</uif-table>
```

Closes #294.
