### PR TITLE
uif-textfield: Demo Multiline & uif-type='password' test

### DIFF
--- a/src/components/textfield/demoMultiline/index.html
+++ b/src/components/textfield/demoMultiline/index.html
@@ -12,6 +12,7 @@
   <script src="../../../../node_modules/angular/angular.min.js"></script>
   <!-- ngofficeuifabric library -->
   <script src="../../../../dist/ngOfficeUiFabric.js"></script>
+  <script src="index.js"></script>
 </head>
 
 <body>

--- a/src/components/textfield/textFieldDirective.spec.ts
+++ b/src/components/textfield/textFieldDirective.spec.ts
@@ -168,7 +168,7 @@ describe('textFieldDirective: <uif-textfield />', () => {
     }));
 
     // input should be able to be of type password
-    // multiline (textbox) is no abel to be set of type password
+    // multiline (textbox) is not abel to be set of type password
     it('input should be able to be of type password', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         let $scope: any = $rootScope.$new();
         let textBox: JQuery = $compile('<uif-textfield ng-model="value" uif-type="password"></uif-textfield>')($scope);

--- a/src/components/textfield/textFieldDirective.spec.ts
+++ b/src/components/textfield/textFieldDirective.spec.ts
@@ -168,7 +168,7 @@ describe('textFieldDirective: <uif-textfield />', () => {
     }));
 
     // input should be able to be of type password
-    // multiline (textbox) is not abel to be set of type password
+    // multiline (textbox) is not able to be set of type password
     it('input should be able to be of type password', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         let $scope: any = $rootScope.$new();
         let textBox: JQuery = $compile('<uif-textfield ng-model="value" uif-type="password"></uif-textfield>')($scope);

--- a/src/components/textfield/textFieldDirective.spec.ts
+++ b/src/components/textfield/textFieldDirective.spec.ts
@@ -166,4 +166,21 @@ describe('textFieldDirective: <uif-textfield />', () => {
         textInput = jQuery(textInput);
         expect(textInput.hasClass('ng-hide')).toBe(true, 'input should be hidden');
     }));
+
+    // input should be able to be of type password
+    // multiline (textbox) is no abel to be set of type password
+    it('input should be able to be of type password', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        let textBox: JQuery = $compile('<uif-textfield ng-model="value" uif-type="password"></uif-textfield>')($scope);
+        textBox = jQuery(textBox[0]);
+        $scope.$apply();
+
+        let textInput: JQuery = textBox.find('input.ms-TextField-field');
+        textInput = jQuery(textInput);
+        expect(textInput.attr('type')).toBe('password', 'input is of type password');
+
+        let textArea: JQuery = textBox.find('textarea.ms-TextField-field');
+        textArea = jQuery(textArea);
+        expect(textArea.attr('type')).toBe(undefined, 'textarea can not be set of type password');
+    }));
 });


### PR DESCRIPTION
Fixed the demo for the case 'uif-multiline'. Added the missing script tag for the demo to load the controller.

Added tests for uif-type="password". 

Closes #300. Closes #301.
