### PR TITLE
fix(datepicker): remove label

### DIFF
--- a/src/components/datepicker/datepickerDirective.spec.ts
+++ b/src/components/datepicker/datepickerDirective.spec.ts
@@ -178,24 +178,6 @@ describe('datepicker: <uif-datepicker />', () => {
 
     }));
 
-    it('Should be able to set start label', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
-        let $scope: any = $rootScope.$new();
-        let datepicker: any = $compile('<uif-datepicker ng-model="value"></uif-datepicker>')($scope);
-        $scope.$digest();
-
-        // verify default value
-        let startLabel: JQuery = jQuery(datepicker[0]).find('.ms-Label');
-        expect(startLabel.text()).toBe('Start Date', 'Default start label should be Start Date');
-
-        datepicker = $compile('<uif-datepicker uif-label="First Date" ng-model="value"></uif-datepicker>')($scope);
-        $scope.$digest();
-
-        // verify custom value
-        startLabel = jQuery(datepicker[0]).find('.ms-Label');
-        expect(startLabel.text()).toBe('First Date', 'Setting custom start date label');
-
-    }));
-
     it('Should be able to set placeholder', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         let $scope: any = $rootScope.$new();
         let datepicker: JQuery = $compile('<uif-datepicker ng-model="value"></uif-datepicker>')($scope);

--- a/src/components/datepicker/datepickerDirective.ts
+++ b/src/components/datepicker/datepickerDirective.ts
@@ -263,12 +263,10 @@ export class DatepickerController {
  *
  *
  * @property {string} uifMonths - Comma separated list of all months
- * @property {string} uifLabel - The label to display above the date picker
  * @property {string} placeholder - The placeholder to display in the text box
  */
 export interface IDatepickerDirectiveScope extends ng.IScope {
     uifMonths: string;
-    uifLabel: string;
     placeholder: string;
     monthsArray: string[];
     highlightedValue: Pickadate.DateItem;
@@ -289,16 +287,13 @@ export interface IDatepickerDirectiveScope extends ng.IScope {
  * <uif-datepicker
  *      ng-model="value"
  *      placeholder="Please, find a date"
- *      uif-months="Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec"
- *      uif-label="Start date"
- * />
+ *      uif-months="Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec" />
  */
 
 export class DatepickerDirective implements ng.IDirective {
     public template: string =
         '<div ng-class="{\'ms-DatePicker\': true, \'is-pickingYears\': ctrl.isPickingYears, \'is-pickingMonths\': ctrl.isPickingMonths}">' +
             '<div class="ms-TextField">' +
-                '<label class="ms-Label">{{uifLabel}}</label>' +
                 '<i class="ms-DatePicker-event ms-Icon ms-Icon--event"></i>' +
                 '<input class="ms-TextField-field" type="text" placeholder="{{placeholder}}">' +
             '</div>' +
@@ -344,7 +339,6 @@ export class DatepickerDirective implements ng.IDirective {
 
     public scope: any = {
         placeholder : '@',
-        uifLabel: '@',
         uifMonths: '@'
     };
     public require: string[] = ['uifDatepicker', '?ngModel'];
@@ -369,10 +363,6 @@ export class DatepickerDirective implements ng.IDirective {
         if (!$scope.uifMonths) {
             $scope.uifMonths = 'Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec';
         }
-        if (!$scope.uifLabel) {
-            $scope.uifLabel = 'Start Date';
-        }
-
         if (!$scope.placeholder) {
             $scope.placeholder = 'Select a date';
         }

--- a/src/components/datepicker/demo/index.html
+++ b/src/components/datepicker/demo/index.html
@@ -61,7 +61,7 @@
   <p>
     This markup: <br />
     <code>
-        &lt;uif-datepicker ng-model=&quot;value_2&quot;&#13;&#10;       uif-months=&quot;Jan,Feb,Maa,Apr,Mei,Jun,Jul,Aug,Sep,Okt,Nov,Dec&quot;&#13;&#10;       uif-label=&quot;Start date&quot;&#13;&#10;       placeholder=&quot;Please, find a date&quot;&#13;&#10;       /&gt;
+        &lt;uif-datepicker ng-model=&quot;value_2&quot;&#13;&#10;       uif-months=&quot;Jan,Feb,Maa,Apr,Mei,Jun,Jul,Aug,Sep,Okt,Nov,Dec&quot;&#13;&#10;       placeholder=&quot;Please, find a date&quot;&#13;&#10;       /&gt;
     </code>
   </p>
 
@@ -71,7 +71,6 @@
 
     <uif-datepicker ng-model="value_2"
        uif-months="Jan,Feb,Maa,Apr,Mei,Jun,Jul,Aug,Sep,Okt,Nov,Dec"
-       uif-label="Start date"
        placeholder="Please, find a date"
        />
     <br/>

--- a/src/components/datepicker/demoBasicUsage/index.html
+++ b/src/components/datepicker/demoBasicUsage/index.html
@@ -1,5 +1,4 @@
 <uif-datepicker ng-model="value"
        uif-months="Jan,Feb,Maa,Apr,Mei,Jun,Jul,Aug,Sep,Okt,Nov,Dec"
-       uif-label="Start date"
        placeholder="Please, find a date"
        />


### PR DESCRIPTION
Removed label from the directive. If developers want to include a label, can use the `<uif-label />` directive.

Closes #295.
