### PR TITLE
fix(textfield): Click on placeholder fixed

### DIFF
--- a/src/components/textfield/demoMultiline/index.html
+++ b/src/components/textfield/demoMultiline/index.html
@@ -33,6 +33,19 @@
     <uif-textfield uif-label="This is the label" uif-description="This is the description" uif-Multiline="true" />
   </p>
 
+<h2>Basic multiline usage with placeholder</h2>
+  <p>
+    This markup: <br />
+    <code>
+      &lt;uif-textfield uif-label=&quot;This is the label&quot; uif-description=&quot;This is the description&quot; uif-multiline=&quot;true&quot; /&gt;
+    </code>
+  </p>
+  <p>
+    Renders this:
+    <br />
+    <uif-textfield placeholder="This is the placeholder" uif-description="This is the description" uif-Multiline="true" />
+  </p>
+
   <h2>Disabled</h2>
   <p>
     This markup: <br />

--- a/src/components/textfield/textFieldDirective.spec.ts
+++ b/src/components/textfield/textFieldDirective.spec.ts
@@ -183,4 +183,24 @@ describe('textFieldDirective: <uif-textfield />', () => {
         textArea = jQuery(textArea);
         expect(textArea.attr('type')).toBe(undefined, 'textarea can not be set of type password');
     }));
+
+    // input with placeholder should focus on click on label
+    // click on the placeholder should hide it an set the focus into the input field
+    it('input with placeholder should focus on click on label', inject (($compile: Function, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        let textBox: JQuery = $compile('<uif-textfield placeholder="Placeholder contents"></uif-textfield>')($scope);
+        textBox = jQuery(textBox[0]);
+        $scope.$apply();
+
+        let label: JQuery = textBox.find('div.ms-TextField--placeholder label.ms-Label');
+        expect(label.html()).toBe('Placeholder contents');
+        expect(label.hasClass('ng-hide')).toBe(false, 'Label should be visible before click');
+
+        let input: JQuery = textBox.find('input.ms-TextField-field');
+        input = jQuery(input);
+
+        spyOn(input[0], 'focus');
+        label.click();
+        expect(input[0].focus).toHaveBeenCalled();
+    }));
 });

--- a/src/components/textfield/textFieldDirective.spec.ts
+++ b/src/components/textfield/textFieldDirective.spec.ts
@@ -202,5 +202,21 @@ describe('textFieldDirective: <uif-textfield />', () => {
         spyOn(input[0], 'focus');
         label.click();
         expect(input[0].focus).toHaveBeenCalled();
+
+        // multiline tests
+        textBox = $compile('<uif-textfield placeholder="Placeholder contents" uif-multiline="true"></uif-textfield>')($scope);
+        textBox = jQuery(textBox[0]);
+        $scope.$apply();
+
+        label = textBox.find('div.ms-TextField--placeholder label.ms-Label');
+        expect(label.html()).toBe('Placeholder contents');
+        expect(label.hasClass('ng-hide')).toBe(false, 'Label should be visible before click');
+
+        input = textBox.find('textarea.ms-TextField-field');
+        input = jQuery(input);
+
+        spyOn(input[0], 'focus');
+        label.click();
+        expect(input[0].focus).toHaveBeenCalled();
     }));
 });

--- a/src/components/textfield/textFieldDirective.ts
+++ b/src/components/textfield/textFieldDirective.ts
@@ -33,6 +33,7 @@ export interface ITextFieldScope extends ng.IScope {
   uifUnderlined: boolean;
   inputFocus: (ev: any) => void;
   inputBlur: (ev: any) => void;
+  labelClick: (ev: any) => void;
   isActive: boolean;
   required: boolean;
   disabled: boolean;
@@ -94,7 +95,7 @@ export class TextFieldDirective implements ng.IDirective {
   '<div ng-class="{\'is-active\': isActive, \'ms-TextField\': true, ' +
   '\'ms-TextField--underlined\': uifUnderlined, \'ms-TextField--placeholder\': placeholder, ' +
   '\'is-required\': required, \'is-disabled\': disabled, \'ms-TextField--multiline\' : uifMultiline }">' +
-  '<label ng-show="labelShown" class="ms-Label">{{uifLabel || placeholder}}</label>' +
+  '<label ng-show="labelShown" class="ms-Label" ng-click="labelClick()">{{uifLabel || placeholder}}</label>' +
   '<input ng-model="ngModel" ng-blur="inputBlur()" ng-focus="inputFocus()" ng-click="inputClick()" ' +
       'class="ms-TextField-field" ng-show="!uifMultiline" ng-disabled="disabled" type="{{uifType}}" />' +
   '<textarea ng-model="ngModel" ng-blur="inputBlur()" ng-focus="inputFocus()" ng-click="inputClick()" ' +
@@ -162,6 +163,12 @@ export class TextFieldDirective implements ng.IDirective {
         scope.labelShown = true;
       }
       scope.isActive = false;
+    };
+    scope.labelClick = function(ev: any): void {
+      if (scope.placeholder) {
+        let input: JQuery = instanceElement.find('input');
+        input[0].focus();
+      }
     };
 
     if (ngModel != null) {

--- a/src/components/textfield/textFieldDirective.ts
+++ b/src/components/textfield/textFieldDirective.ts
@@ -166,9 +166,10 @@ export class TextFieldDirective implements ng.IDirective {
     };
     scope.labelClick = function(ev: any): void {
       if (scope.placeholder) {
-        let input: JQuery = instanceElement.find('input');
-        input[0].focus();
-      }
+          let input: JQuery = scope.uifMultiline  ? instanceElement.find('textarea')
+                                                  : instanceElement.find('input');
+          input[0].focus();
+        }
     };
 
     if (ngModel != null) {


### PR DESCRIPTION
Clicking on the placeholder did not remove the placeholder and focus the underlying input field.

This PR adds a label (as placeholder) click function and tests.

Closes #305.
