### PR TITLE
feat(toggle): add ng checkbox attributes support

### DIFF
--- a/src/components/toggle/toggleDirective.spec.ts
+++ b/src/components/toggle/toggleDirective.spec.ts
@@ -93,4 +93,63 @@ describe('toggleDirective: <uif-toggle />', () => {
         input = toggle.find('input');
         expect(input.attr('disabled')).toBe(undefined, 'Input element is not disabled');
     }));
+
+    it('should call the function passed to ng-change on toggle', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        $scope.testValue = false;
+        $scope.toggled = false;
+        $scope.toggleMe = (someValue) => {
+            // dummy function.
+        };
+
+        spyOn($scope, 'toggleMe');
+
+        let toggle: JQuery = $compile('<uif-toggle uif-label-off="No" uif-label-on="Yes" ng-model="toggled"'
+            + 'ng-change="toggleMe(testValue)"></uif-toggle>')($scope);
+        toggle = jQuery(toggle[0]);
+        $scope.$apply();
+
+        let checkBox: JQuery = toggle.find('input.ms-Toggle-input');
+        checkBox.click();
+        $scope.$apply();
+
+        expect($scope.toggleMe).toHaveBeenCalledWith($scope.testValue);
+
+    }));
+
+    it('display the attribute ng-true-value only if passed', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        $scope.toggled = false;
+
+        let trueToggle: JQuery = $compile('<uif-toggle uif-label-off="No" uif-label-on="Yes" ng-model="toggled"'
+            + 'ng-true-value="\'YES\'"></uif-toggle>')($scope);
+        $scope.$apply();
+        let trueInput: JQuery = trueToggle.find('input');
+
+        expect(trueInput.attr('ng-true-value') === "'YES'").toBe(true);
+
+        let toggle: JQuery = $compile('<uif-toggle uif-label-off="No" uif-label-on="Yes" ng-model="toggled"></uif-toggle>')($scope);
+        $scope.$apply();
+        let input: JQuery = toggle.find('input');
+
+        expect(input.attr('ng-true-value') === undefined).toBe(true);
+    }));
+
+    it('display the attribute ng-false-value only if passed', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        $scope.toggled = false;
+
+        let falseToggle: JQuery = $compile('<uif-toggle uif-label-off="No" uif-label-on="Yes" ng-model="toggled"'
+            + 'ng-false-value="\'NO\'"></uif-toggle>')($scope);
+        $scope.$apply();
+        let falseInput: JQuery = falseToggle.find('input');
+
+        expect(falseInput.attr('ng-false-value') === "'NO'").toBe(true);
+
+        let toggle: JQuery = $compile('<uif-toggle uif-label-off="No" uif-label-on="Yes" ng-model="toggled"></uif-toggle>')($scope);
+        $scope.$apply();
+        let input: JQuery = toggle.find('input');
+
+        expect(input.attr('ng-false-value') === undefined).toBe(true);
+    }));
 });

--- a/src/components/toggle/toggleDirective.ts
+++ b/src/components/toggle/toggleDirective.ts
@@ -15,6 +15,12 @@ import * as ng from 'angular';
  * @property {string} uifLabelOff     - The label to display when not toggled
  * @property {string} uifLabelOn      - The label to display when toggled
  * @property {string} uifTextLocation - Location of the label (left or right), compared to the toggle  
+ * @property {string} uniqueId
+ * @property {string} textLocation
+ * @property {string} disabled
+ * @property {string} ngChange        - Expression to be called on the ngChange event of the input element
+ * @property {string} ngTrueValue     - Pass a constant for the ng-true-value of the input element
+ * @property {string} ngFalseValue    - Pass a constant for the ng-false-value of the input element
  */
 
 export interface IToggleScope extends ng.IScope {
@@ -25,6 +31,9 @@ export interface IToggleScope extends ng.IScope {
     uniqueId: number;
     textLocation: string;
     disabled: boolean;
+    ngChange: string;
+    ngTrueValue: string;
+    ngFalseValue: string;
 }
 
 /**
@@ -46,7 +55,9 @@ export interface IToggleScope extends ng.IScope {
 export class ToggleDirective implements ng.IDirective {
     public template: string = '<div ng-class="[\'ms-Toggle\', textLocation, {\'is-disabled\': disabled}]">' +
                  '<span class="ms-Toggle-description"><ng-transclude/></span>' +
-                '<input type="checkbox" id="{{::$id}}" class="ms-Toggle-input" ng-model="ngModel" ng-disabled="disabled"/>' +
+                '<input type="checkbox" id="{{::$id}}" class="ms-Toggle-input" ' +
+                'ng-model="ngModel" ng-change="ngChange()" ng-disabled="disabled" ' +
+                'ng-attr-ng-true-value="{{ngTrueValue || undefined}}" ng-attr-ng-false-value="{{ngFalseValue || undefined}}" />' +
                 '<label for="{{::$id}}" class="ms-Toggle-field">' +
                     '<span class="ms-Label ms-Label--off">{{uifLabelOff}}</span>' +
                     '<span class="ms-Label ms-Label--on">{{uifLabelOn}}</span>' +
@@ -55,7 +66,10 @@ export class ToggleDirective implements ng.IDirective {
     public restrict: string = 'E';
     public transclude: boolean = true;
     public scope: {} = {
+        ngChange: '&?',
+        ngFalseValue: '@?',
         ngModel: '=?',
+        ngTrueValue: '@?',
         uifLabelOff: '@',
         uifLabelOn: '@',
         uifTextLocation: '@'


### PR DESCRIPTION
An angular input checkbox supports the use of `ng-change`,
`ng-true-value` and `ng-false-value`. The toggle component
now supports these attributes.

Closes #289
