### PR TITLE
feat(table): new table type in Fabric 2.4.x

### DIFF
--- a/src/components/table/demo/index.html
+++ b/src/components/table/demo/index.html
@@ -327,6 +327,61 @@
         </uif-table-head>
     </uif-table>
   </p>
+  
+  <h2>Fixed table rendering</h2>
+  <p>
+    This markup: <br />
+    <pre>
+&lt;uif-table uif-table-type=&quot;fixed&quot;&gt;
+    &lt;uif-table-head&gt;
+        &lt;uif-table-row&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-header uif-order-by="fileName"&gt;File name&lt;/uif-table-header&gt;
+            &lt;uif-table-header&gt;Location&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="modified"&gt;Modified&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="type"&gt;Type&lt;/uif-table-header&gt;
+            &lt;uif-table-header uif-order-by="size"&gt;Size&lt;/uif-table-header&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-head&gt;
+    &lt;uif-table-body&gt;
+        &lt;uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}<!---->}"&gt;
+            &lt;uif-table-row-select&gt;&lt;/uif-table-row-select&gt;
+            &lt;uif-table-cell&gt;{{f.fileName}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.location}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.modified | date}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.type}}&lt;/uif-table-cell&gt;
+            &lt;uif-table-cell&gt;{{f.size}}&lt;/uif-table-cell&gt;
+        &lt;/uif-table-row&gt;
+    &lt;/uif-table-body&gt;
+&lt;/uif-table&gt;
+    </pre>
+  </p>
+  <p ng-controller="demoController">
+    Renders this (selecting multiple rows enabled, one row marked as selected):
+    <br />
+    <uif-table uif-table-type="fixed">
+        <uif-table-head>
+            <uif-table-row>
+                <uif-table-row-select></uif-table-row-select>
+                <uif-table-header uif-order-by="fileName">File name</uif-table-header>
+                <uif-table-header>Location</uif-table-header>
+                <uif-table-header uif-order-by="modified">Modified</uif-table-header>
+                <uif-table-header uif-order-by="type">Type</uif-table-header>
+                <uif-table-header uif-order-by="size">Size</uif-table-header>
+            </uif-table-row>
+        </uif-table-head>
+        <uif-table-body>
+            <uif-table-row ng-repeat="f in files | orderBy:table.orderBy:!table.orderAsc" uif-item="f" uif-selected="{{f.isSelected}}">
+                <uif-table-row-select></uif-table-row-select>
+                <uif-table-cell>{{f.fileName}}</uif-table-cell>
+                <uif-table-cell>{{f.location}}</uif-table-cell>
+                <uif-table-cell>{{f.modified | date}}</uif-table-cell>
+                <uif-table-cell>{{f.type}}</uif-table-cell>
+                <uif-table-cell>{{f.size}}</uif-table-cell>
+            </uif-table-row>
+        </uif-table-head>
+    </uif-table>
+  </p>
 </body>
 
 </html>

--- a/src/components/table/tableDirective.spec.ts
+++ b/src/components/table/tableDirective.spec.ts
@@ -37,7 +37,7 @@ describe('tableDirective: <uif-table />', () => {
         expect(element).toHaveClass('ms-Table--fixed');
     }));
 
-    it('should set correct Office UI Fabric fulid class on the table for the \'uif-table-type\' attribute',
+    it('should set correct Office UI Fabric fluid class on the table for the \'uif-table-type\' attribute',
        inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table uif-table-type="fluid"></uif-table>');
         $compile(element)(scope);

--- a/src/components/table/tableDirective.spec.ts
+++ b/src/components/table/tableDirective.spec.ts
@@ -29,6 +29,31 @@ describe('tableDirective: <uif-table />', () => {
         expect(element).toHaveClass('ms-Table');
     }));
 
+    it('should set correct Office UI Fabric fixed class on the table for the \'uif-table-type\' attribute',
+       inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        element = ng.element('<uif-table uif-table-type="fixed"></uif-table>');
+        $compile(element)(scope);
+        scope.$digest();
+        expect(element).toHaveClass('ms-Table--fixed');
+    }));
+
+    it('should set correct Office UI Fabric fulid class on the table for the \'uif-table-type\' attribute',
+       inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        element = ng.element('<uif-table uif-table-type="fluid"></uif-table>');
+        $compile(element)(scope);
+        scope.$digest();
+        expect(element).not.toHaveClass('ms-Table--fixed');
+    }));
+
+    it('should throw an error on an invalid value for the \'uif-table-type\' attribute',
+       inject(($compile: Function, $rootScope: ng.IRootScopeService, $log: ng.ILogService) => {
+        element = ng.element('<uif-table uif-table-type="invalid"></uif-table>');
+        $compile(element)(scope);
+        scope.$digest();
+
+        expect($log.error.logs.length).toEqual(1);
+     }));
+
     it('should render the row using a tr tag', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
         element = ng.element('<uif-table><uif-table-row></uif-table-row></uif-table>');
         $compile(element)(scope);

--- a/src/components/table/tableDirective.ts
+++ b/src/components/table/tableDirective.ts
@@ -2,6 +2,7 @@
 
 import * as ng from 'angular';
 import {TableRowSelectModeEnum} from './tableRowSelectModeEnum';
+import {TableTypeEnum} from './tableTypeEnum';
 
 /**
  * @ngdoc interface
@@ -15,13 +16,15 @@ import {TableRowSelectModeEnum} from './tableRowSelectModeEnum';
  * @property {boolean} orderAsc - Specifies whether the data in the table should be sort ascending or descending.
  *                                Default `true` (sorting ascending)
  * @property {string} rowSelectMode - Specifies the row selection mode used by the table
- * @property {ITableRowScope[]} - Contains the data rows (all except the header row) that belong to the table 
+ * @property {ITableRowScope[]} - Contains the data rows (all except the header row) that belong to the table
  */
 export interface ITableScope extends ng.IScope {
     orderBy?: string;
     orderAsc: boolean;
     rowSelectMode?: string;
     rows: ITableRowScope[];
+    tableType: string;
+    tableTypeClass: string;
 }
 
 class TableController {
@@ -95,9 +98,14 @@ class TableController {
  *                                         Possible values: none - selecting rows is not possible;
  *                                                          single - only one row can be selected;
  *                                                          multiple - multiple rows can be selected;
+ * @property {string} uifTableType      - Specifies whether the table is renders in fuild or fixed mode.
+ *                                        Possible values: fixed    - the table is rendered in fixed style.
+ *                                                                    Added with Fabric 2.4.
+ *                                                         fluid    - the table style is fuild (Default)
  */
 export interface ITableAttributes extends ng.IAttributes {
     uifRowSelectMode?: string;
+    uifTableType?: string;
 }
 
 /**
@@ -139,7 +147,7 @@ export class TableDirective implements ng.IDirective {
     public restrict: string = 'E';
     public transclude: boolean = true;
     public replace: boolean = true;  // required for correct HTML rendering
-    public template: string = '<table class="ms-Table" ng-transclude></table>';
+    public template: string = '<table ng-class="[\'ms-Table\', tableTypeClass]" ng-transclude></table>';
     public controller: any = TableController;
     public controllerAs: string = 'table';
 
@@ -162,6 +170,22 @@ export class TableDirective implements ng.IDirective {
 
         if (scope.rowSelectMode === undefined) {
             scope.rowSelectMode = TableRowSelectModeEnum[TableRowSelectModeEnum.none];
+        }
+
+        if (attrs.uifTableType !== undefined && attrs.uifTableType !== null) {
+            if (TableTypeEnum[attrs.uifTableType] === undefined) {
+                controller.$log.error('Error [ngOfficeUiFabric] officeuifabric.components.table. ' +
+                '\'' + attrs.uifTableType + '\' is not a valid option for \'uif-table-type\'. ' +
+                'Valid options are fixed|fluid.');
+            } else {
+                scope.tableType = attrs.uifTableType;
+            }
+        }
+        if (scope.tableType === undefined) {
+            scope.tableType = TableTypeEnum[TableTypeEnum.fluid];
+        }
+        if (scope.tableType === TableTypeEnum[TableTypeEnum.fixed]) {
+            scope.tableTypeClass = 'ms-Table--fixed';
         }
     }
 }

--- a/src/components/table/tableDirective.ts
+++ b/src/components/table/tableDirective.ts
@@ -98,10 +98,10 @@ class TableController {
  *                                         Possible values: none - selecting rows is not possible;
  *                                                          single - only one row can be selected;
  *                                                          multiple - multiple rows can be selected;
- * @property {string} uifTableType      - Specifies whether the table is renders in fuild or fixed mode.
+ * @property {string} uifTableType      - Specifies whether the table is rendered in fluid or fixed mode.
  *                                        Possible values: fixed    - the table is rendered in fixed style.
  *                                                                    Added with Fabric 2.4.
- *                                                         fluid    - the table style is fuild (Default)
+ *                                                         fluid    - the table style is fluid (Default)
  */
 export interface ITableAttributes extends ng.IAttributes {
     uifRowSelectMode?: string;

--- a/src/components/table/tableTypeEnum.ts
+++ b/src/components/table/tableTypeEnum.ts
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * Enum for supported input types of the uif-table directive
+ * This enum is intended to be used as a string.
+ *
+ * @readonly
+ * @enum {string}
+ * @usage
+ *
+ * This is used to generate the string that you pass into the `uif-table-type` attribute of the following components:
+ *
+ * let style: string = InputTypeEnum[InputTypeEnum.text];
+ */
+export enum TableTypeEnum {
+  fluid,
+  fixed
+}

--- a/src/components/table/tableTypeEnum.ts
+++ b/src/components/table/tableTypeEnum.ts
@@ -10,7 +10,7 @@
  *
  * This is used to generate the string that you pass into the `uif-table-type` attribute of the following components:
  *
- * let style: string = InputTypeEnum[InputTypeEnum.text];
+ * let style: string = TableTypeEnum[TableTypeEnum.text];
  */
 export enum TableTypeEnum {
   fluid,


### PR DESCRIPTION
Fabric 2.4.x introduces a new table type (fixed).
This PR adds a new attribute `uif-table-type`.
`uif-table-type` {string} - Values: fluid (Default) and fixed
- adds uif-table-type
- adds tests
- adds demo

Requires Fabric 2.4.x.

Closes #308.
