### PR TITLE
fix(pivot): fixed Pivot demo to display contextual menu in ellipsis

### DIFF
--- a/src/components/pivot/demo/index.html
+++ b/src/components/pivot/demo/index.html
@@ -13,6 +13,11 @@
   <!-- ngofficeuifabric library -->
   <script src="../../../../dist/ngOfficeUIFabric.js"></script>
   <script src="index.js"></script>
+  <style type="text/css">
+    .ms-Pivot {
+      overflow-x: initial;
+    }
+  </style>
 </head>
 
 <body ng-app="demoApp">
@@ -25,6 +30,15 @@
   <div>
     Pivot renders set of links/buttons which can be selected. After being clicked, element is in <i>selected</i> state.
     If specified, it can be bound to scope via <code>uif-selected</code> attribute, allowing to programatically control which link/tab should be selected.
+  </div>
+
+  <div>
+    Due to small bug in <em>Office UI Fabric</em>, elements inside ellipsis might not display correctly. Until its fixed within Fabric UI, you can temporary fix it by overriding a CSS style like this:
+    <code>
+    .ms-Pivot {
+      overflow-x: initial;
+    }
+    </code>
   </div>
 
   <p>&nbsp;</p>
@@ -77,7 +91,7 @@
     </pre>
 
     <p>Gives following output:</p>
-    <uif-pivot uif-type="{{vm.selectedType}}" uif-size="{{vm.selectedSize}}" uif-pivots="vm.pivots" uif-selected="vm.selectedPivot" id="msPivot">
+    <uif-pivot uif-type="{{vm.selectedType}}" uif-size="{{vm.selectedSize}}" uif-pivots="vm.pivots" uif-selected="vm.selectedPivot" id="msPivot" class="pivot-overflow-fix">
       <uif-pivot-ellipsis ng-click="openMenu()">
         <uif-contextual-menu uif-is-open="vm.menuOpened" uif-close-on-click="true">
           <uif-contextual-menu-item uif-text="'New'"></uif-contextual-menu-item>


### PR DESCRIPTION
Pivot demo did not display properly the contextual menu that is part of the ellipsis component. This has been identified as a bug within Fabric UI ([Pivot: ContextualMenu not showing](https://github.com/OfficeDev/Office-UI-Fabric/issues/508)).

Demo now has a workaround for that issue until it will be solved in Fabric UI. The workaround is overriding the `overflow-x` property of the Pivot element.
