### PR TITLE
fix: Issue #330 uif-breadcrumb with ng-repeat

### DIFF
--- a/src/components/breadcrumb/breadcrumbDirective.spec.ts
+++ b/src/components/breadcrumb/breadcrumbDirective.spec.ts
@@ -16,11 +16,11 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
 
   beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: Function) => {
     let html: string = '<uif-breadcrumb>' +
-                       '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/1">ngOfficeUiFabric-1</uif-breadcrumb-link>' +
-                       '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/2">ngOfficeUiFabric-2</uif-breadcrumb-link>' +
-                       '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/3">ngOfficeUiFabric-3</uif-breadcrumb-link>' +
-                       '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/4">ngOfficeUiFabric-4</uif-breadcrumb-link>' +
-                       '</uif-breadcrumb>';
+      '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/1">ngOfficeUiFabric-1</uif-breadcrumb-link>' +
+      '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/2">ngOfficeUiFabric-2</uif-breadcrumb-link>' +
+      '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/3">ngOfficeUiFabric-3</uif-breadcrumb-link>' +
+      '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/4">ngOfficeUiFabric-4</uif-breadcrumb-link>' +
+      '</uif-breadcrumb>';
     scope = $rootScope;
 
     element = $compile(html)(scope);    // jqLite object
@@ -35,9 +35,9 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
     expect(element[0]).toHaveClass('ms-Breadcrumb');
 
     // verify nested should contain UL
-    expect(element.find('ul').length).toBe(1);
+    expect(element.find('ul').length).toBe(2);
     let ulElement: JQuery = element.find('ul');
-    expect(ulElement[0]).toHaveClass('ms-Breadcrumb-list');
+    expect(ulElement[1]).toHaveClass('ms-Breadcrumb-list');
 
     // look at all list items...
     // ... get all list items...

--- a/src/components/breadcrumb/breadcrumbDirective.spec.ts
+++ b/src/components/breadcrumb/breadcrumbDirective.spec.ts
@@ -74,4 +74,60 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
 
   });
 
+  it('should create correct HTML with ng-repeat', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+
+    let html: string = '' +
+      '<uif-breadcrumb> ' +
+      '<uif-breadcrumb-link ng-repeat="item in items" ng-href="http://ngofficeuifabric.com/{{item}}">' +
+      'ngOfficeUiFabric-{{item}}</uif-breadcrumb-link>' +
+      '</uif-breadcrumb>';
+    let testScope: any = $rootScope.$new();
+    testScope.items = [1, 2, 3, 4];
+
+    element = $compile(html)(testScope);    // jqLite object
+    element = jQuery(element[0]);       // jQuery object
+
+    testScope.$digest();
+    // verify top breadcrumb container & correct style
+    expect(element.prop('tagName')).toEqual('DIV');
+    expect(element[0]).toHaveClass('ms-Breadcrumb');
+
+    // verify nested should contain UL
+    expect(element.find('ul').length).toBe(2);
+    let ulElement: JQuery = element.find('ul');
+    expect(ulElement[1]).toHaveClass('ms-Breadcrumb-list');
+
+    // look at all list items...
+    // ... get all list items...
+    let liElements: JQuery = ulElement.find('li');
+    // ... make sure there are 4 of them
+    expect(liElements.length).toBe(4, 'should only 4 list items present');
+
+    // loop through all list items...
+    for (let itemIndex: number = 0; itemIndex < liElements.length; itemIndex++) {
+      // for the list item...
+      let liElement: JQuery = $(liElements.get(itemIndex));
+
+      // make sure it has correct css
+      expect(liElement[0]).toHaveClass('ms-Breadcrumb-listItem');
+
+      // make sure it has exactly 1 nested link...
+      expect(liElement.find('a').length).toBe(1, 'expected to find exactly 1 <a> element');
+      let aElement: JQuery = liElement.find('a');
+      // ... with correct style...
+      expect(aElement[0]).toHaveClass('ms-Breadcrumb-itemLink');
+      // ... with correct tabindex...
+      expect(aElement[0]).toHaveAttr('tabindex', `${itemIndex + 2}`);
+      // ... with correct target...
+      expect(aElement[0]).toHaveAttr('href', `http://ngofficeuifabric.com/${itemIndex + 1}`);
+      // ... with correct value...
+      expect(aElement[0].innerText).toBe(`ngOfficeUiFabric-${itemIndex + 1}`);
+
+      // make sure it has exactly 1 cheveron icon...
+      let iElement: JQuery = liElement.find('i');
+      expect(iElement.length).toBe(1);
+      // ... with correct styles...
+      expect(iElement[0]).toHaveClass('ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight');
+    }
+  }));
 });

--- a/src/components/breadcrumb/breadcrumbDirective.ts
+++ b/src/components/breadcrumb/breadcrumbDirective.ts
@@ -61,7 +61,8 @@ export class BreadcrumbLinkDirective implements ng.IDirective {
     ctrl: BreadcrumbController,
     transclude: ng.ITranscludeFunction): void {
 
-    scope.uifTabindex = parseInt(attributes.uifTabindex, null) + 1;
+    let tabindex: number = Array.prototype.indexOf.call(instanceElement.parent().children(), instanceElement[0]) + 2;
+    scope.uifTabindex = tabindex;
   }
 }
 
@@ -135,15 +136,6 @@ export class BreadcrumbDirective implements ng.IDirective {
       ul.append(breadcrumbLinks);
     });
 
-    // for regular rendering without ng-repeat
-    let tabIndex: number = 1;
-    let breadcrumbLinks: JQuery = ul.find('li');
-    for (let linkIndex: number = 1; linkIndex < breadcrumbLinks.length; linkIndex += 2) {
-      let currentLi: JQuery = ng.element(breadcrumbLinks[linkIndex]);
-      if (currentLi != null) {
-        ng.element(currentLi[0].querySelector('.ms-Breadcrumb-itemLink')).attr('tabindex', ++tabIndex);
-      }
-    }
   }
 };
 

--- a/src/components/breadcrumb/demo/index.html
+++ b/src/components/breadcrumb/demo/index.html
@@ -46,7 +46,7 @@
   </p>
   <p ng-controller="demoCtrl">
     <uif-breadcrumb>
-      <uif-breadcrumb-link ng-href="{{item}}" uif-tabindex="{{$index}}" ng-repeat="item in items">{{item}}</uif-breadcrumb-link>
+      <uif-breadcrumb-link ng-href="{{item}}" ng-repeat="item in items">{{item}}</uif-breadcrumb-link>
     </uif-breadcrumb>
   </p>
 </body>

--- a/src/components/breadcrumb/demo/index.html
+++ b/src/components/breadcrumb/demo/index.html
@@ -1,40 +1,54 @@
 <!DOCTYPE html>
 <html>
 
-  <head>
-    <title>ngOfficeUiFabric | uif-Breadcrumb demo</title>
-    <meta charset="utf-8">
+<head>
+  <title>ngOfficeUiFabric | uif-Breadcrumb demo</title>
+  <meta charset="utf-8">
 
-    <!-- office ui fabric css -->
-    <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.min.css" />
-    <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.components.min.css" />
+  <!-- office ui fabric css -->
+  <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.min.css" />
+  <link rel="stylesheet" href="../../../../node_modules/office-ui-fabric/dist/css/fabric.components.min.css" />
 
-    <!-- angular library -->
-    <script src="../../../../node_modules/angular/angular.js"></script>
-    <!-- ngofficeuifabric library -->
-    <script src="../../../../dist/ngOfficeUiFabric.js"></script>
-    <script src="index.js"></script>
-  </head>
+  <!-- angular library -->
+  <script src="../../../../node_modules/angular/angular.js"></script>
+  <!-- ngofficeuifabric library -->
+  <script src="../../../../dist/ngOfficeUiFabric.js"></script>
+  <script src="index.js"></script>
+</head>
 
-  <body ng-app="demoApp">
-    <h1 class="ms-font-su">Breadcrumb Demo | &lt;uif-breadcrumb&gt;</h1>
-    <em>In order for this demo to work you must first build the library in debug mode.</em>
+<body ng-app="demoApp">
+  <h1 class="ms-font-su">Breadcrumb Demo | &lt;uif-breadcrumb&gt;</h1>
+  <em>In order for this demo to work you must first build the library in debug mode.</em>
 
-    <!-- first example -->
-    <p>To render breadcrumb, use the following markup:
-      <br/>
-      <pre>
+  <!-- first example -->
+  <p>To render breadcrumb, use the following markup:
+    <br/>
+    <pre>
         &lt;uif-breadcrumb&gt;&#13;&#10;          &lt;uif-breadcrumb-link ng-href=&quot;\&apos;http://github1.com\&apos;&quot;&gt;GitHub1&lt;/uif-breadcrumb-link&gt;&#13;&#10;          &lt;uif-breadcrumb-link ng-href=&quot;\&apos;http://github2.com\&apos;&quot;&gt;GitHub2&lt;/uif-breadcrumb-link&gt;&#13;&#10;          &lt;uif-breadcrumb-link ng-href=&quot;\&apos;http://github3.com\&apos;&quot;&gt;GitHub3&lt;/uif-breadcrumb-link&gt;&#13;&#10;          &lt;uif-breadcrumb-link ng-href=&quot;\&apos;http://github4.com\&apos;&quot;&gt;GitHub4&lt;/uif-breadcrumb-link&gt;&#13;&#10;        &lt;/uif-breadcrumb&gt;
       </pre>
-    </p>
+  </p>
 
-    <p>
-      <uif-breadcrumb>
-        <uif-breadcrumb-link ng-href="\'http://github1.com\'">GitHub1</uif-breadcrumb-link>
-        <uif-breadcrumb-link ng-href="\'http://github2.com\'">GitHub2</uif-breadcrumb-link>
-        <uif-breadcrumb-link ng-href="\'http://github3.com\'">GitHub3</uif-breadcrumb-link>
-        <uif-breadcrumb-link ng-href="\'http://github4.com\'">GitHub4</uif-breadcrumb-link>
-      </uif-breadcrumb>
-    </p>
-  </body>
+  <p>
+    <uif-breadcrumb>
+      <uif-breadcrumb-link ng-href="\'http://github1.com\'">GitHub1</uif-breadcrumb-link>
+      <uif-breadcrumb-link ng-href="\'http://github2.com\'">GitHub2</uif-breadcrumb-link>
+      <uif-breadcrumb-link ng-href="\'http://github3.com\'">GitHub3</uif-breadcrumb-link>
+      <uif-breadcrumb-link ng-href="\'http://github4.com\'">GitHub4</uif-breadcrumb-link>
+    </uif-breadcrumb>
+  </p>
+  <h2>ng-repeat</h2>
+  <p>
+    <pre>
+      &lt;uif-breadcrumb&gt;
+      &lt;uif-breadcrumb-link ng-href=&quot;{{item}}&quot; ng-repeat=&quot;item in items&quot;&gt;{{item}}&lt;/uif-breadcrumb-link&gt;
+      &lt;/uif-breadcrumb&gt;
+    </pre>
+  </p>
+  <p ng-controller="demoCtrl">
+    <uif-breadcrumb>
+      <uif-breadcrumb-link ng-href="{{item}}" uif-tabindex="{{$index}}" ng-repeat="item in items">{{item}}</uif-breadcrumb-link>
+    </uif-breadcrumb>
+  </p>
+</body>
+
 </html>

--- a/src/components/breadcrumb/demo/index.js
+++ b/src/components/breadcrumb/demo/index.js
@@ -4,3 +4,7 @@ var demoApp = angular.module('demoApp', [
   'officeuifabric.core',
   'officeuifabric.components.breadcrumb'
 ]);
+
+demoApp.controller('demoCtrl', ['$scope', function ($scope) {
+  $scope.items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+}]);


### PR DESCRIPTION
`uif-breadcrumb` used a custom transclude function. Ng-repeat didn't work with this setting.

This PR changes the transclude function and the uif-breadcrumb-link directive to support ng-repeat.
- New test for ng-repeat
- New demo for ng-repeat 

Closes #330.
