### PR TITLE
fix(breadcrumb): missing responsiveness

### DIFF
--- a/src/components/breadcrumb/breadcrumbDirective.spec.ts
+++ b/src/components/breadcrumb/breadcrumbDirective.spec.ts
@@ -4,7 +4,7 @@ import * as ng from 'angular';
 
 describe('breadcrumbDirective <uif-breadcrumb />', () => {
   let element: JQuery;
-  let scope: ng.IScope;
+  let scope: any;
 
   /**
    * before each test load all required modules
@@ -15,19 +15,26 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
   });
 
   beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: Function) => {
-    let html: string = '<uif-breadcrumb>' +
-      '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/1">ngOfficeUiFabric-1</uif-breadcrumb-link>' +
-      '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/2">ngOfficeUiFabric-2</uif-breadcrumb-link>' +
-      '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/3">ngOfficeUiFabric-3</uif-breadcrumb-link>' +
-      '<uif-breadcrumb-link ng-href="http://ngofficeuifabric.com/4">ngOfficeUiFabric-4</uif-breadcrumb-link>' +
-      '</uif-breadcrumb>';
+
+
+    let html: string = '<uif-breadcrumb uif-breadcrumb-links="breadcrumbLinks"></uif-breadcrumb>';
     scope = $rootScope;
+    scope.breadcrumbLinks = [
+      {href: 'http://ngofficeuifabric.com/1', linkText: 'ngOfficeUiFabric-1'},
+      {href: 'http://ngofficeuifabric.com/2', linkText: 'ngOfficeUiFabric-2'},
+      {href: 'http://ngofficeuifabric.com/3', linkText: 'ngOfficeUiFabric-3'},
+      {href: 'http://ngofficeuifabric.com/4', linkText: 'ngOfficeUiFabric-4'}
+    ];
 
     element = $compile(html)(scope);    // jqLite object
     element = jQuery(element[0]);       // jQuery object
 
     scope.$digest();
   }));
+
+  it('should not have is-overflow class', () => {
+    expect(element).not.toHaveClass('is-overflow');
+  });
 
   it('should create correct HTML', () => {
     // verify top breadcrumb container & correct style
@@ -74,60 +81,114 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
 
   });
 
-  it('should create correct HTML with ng-repeat', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+  describe('responsive breadCrumb', () => {
+    beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: ng.ICompileService) => {
 
-    let html: string = '' +
-      '<uif-breadcrumb> ' +
-      '<uif-breadcrumb-link ng-repeat="item in items" ng-href="http://ngofficeuifabric.com/{{item}}">' +
-      'ngOfficeUiFabric-{{item}}</uif-breadcrumb-link>' +
-      '</uif-breadcrumb>';
-    let testScope: any = $rootScope.$new();
-    testScope.items = [1, 2, 3, 4];
+      let html: string = '<uif-breadcrumb uif-breadcrumb-links="breadcrumbLinks"></uif-breadcrumb>';
+      scope = $rootScope.$new();
+      scope.breadcrumbLinks = [
+        {href: 'http://ngofficeuifabric.com/1', linkText: 'ngOfficeUiFabric-1'},
+        {href: 'http://ngofficeuifabric.com/2', linkText: 'ngOfficeUiFabric-2'},
+        {href: 'http://ngofficeuifabric.com/3', linkText: 'ngOfficeUiFabric-3'},
+        {href: 'http://ngofficeuifabric.com/4', linkText: 'ngOfficeUiFabric-4'},
+        {href: 'http://ngofficeuifabric.com/5', linkText: 'ngOfficeUiFabric-5'},
+        {href: 'http://ngofficeuifabric.com/6', linkText: 'ngOfficeUiFabric-6'}
+      ];
 
-    element = $compile(html)(testScope);    // jqLite object
-    element = jQuery(element[0]);       // jQuery object
+      element = $compile(html)(scope);    // jqLite object
+      element = jQuery(element[0]);       // jQuery object
 
-    testScope.$digest();
-    // verify top breadcrumb container & correct style
-    expect(element.prop('tagName')).toEqual('DIV');
-    expect(element[0]).toHaveClass('ms-Breadcrumb');
+      scope.$digest();
+    }));
 
-    // verify nested should contain UL
-    expect(element.find('ul').length).toBe(2);
-    let ulElement: JQuery = element.find('ul');
-    expect(ulElement[1]).toHaveClass('ms-Breadcrumb-list');
+    it('large screen: max 4 items should be visible', () => {
 
-    // look at all list items...
-    // ... get all list items...
-    let liElements: JQuery = ulElement.find('li');
-    // ... make sure there are 4 of them
-    expect(liElements.length).toBe(4, 'should only 4 list items present');
+      let visibleLinks: JQuery = element.find('.ms-Breadcrumb-list li');
 
-    // loop through all list items...
-    for (let itemIndex: number = 0; itemIndex < liElements.length; itemIndex++) {
-      // for the list item...
-      let liElement: JQuery = $(liElements.get(itemIndex));
+      expect(visibleLinks.length === 4).toBeTruthy();
 
-      // make sure it has correct css
-      expect(liElement[0]).toHaveClass('ms-Breadcrumb-listItem');
+      let firstLink: JQuery = visibleLinks.eq(0).find('a');
+      expect(firstLink).toHaveAttr('href', 'http://ngofficeuifabric.com/3');
 
-      // make sure it has exactly 1 nested link...
-      expect(liElement.find('a').length).toBe(1, 'expected to find exactly 1 <a> element');
-      let aElement: JQuery = liElement.find('a');
-      // ... with correct style...
-      expect(aElement[0]).toHaveClass('ms-Breadcrumb-itemLink');
-      // ... with correct tabindex...
-      expect(aElement[0]).toHaveAttr('tabindex', `${itemIndex + 2}`);
-      // ... with correct target...
-      expect(aElement[0]).toHaveAttr('href', `http://ngofficeuifabric.com/${itemIndex + 1}`);
-      // ... with correct value...
-      expect(aElement[0].innerText).toBe(`ngOfficeUiFabric-${itemIndex + 1}`);
+      let lastLink: JQuery = visibleLinks.eq(3).find('a');
+      expect(lastLink).toHaveAttr('href', 'http://ngofficeuifabric.com/6');
+    });
 
-      // make sure it has exactly 1 cheveron icon...
-      let iElement: JQuery = liElement.find('i');
-      expect(iElement.length).toBe(1);
-      // ... with correct styles...
-      expect(iElement[0]).toHaveClass('ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight');
-    }
-  }));
+    it('large screen: max 2 items should be in contextual menu', () => {
+
+      let overflowLinks: JQuery = element.find('.ms-ContextualMenu li');
+
+      expect(overflowLinks.length === 2).toBeTruthy();
+
+      let firstLink: JQuery = overflowLinks.eq(0).find('a');
+      expect(firstLink).toHaveAttr('href', 'http://ngofficeuifabric.com/1');
+
+      let lastLink: JQuery = overflowLinks.eq(1).find('a');
+      expect(lastLink).toHaveAttr('href', 'http://ngofficeuifabric.com/2');
+    });
+
+    it('should have is-overflow class', () => {
+      expect(element).toHaveClass('is-overflow');
+    });
+
+    it('should close overflow menu on click outside', () => {
+      let overflowButton: JQuery = element.find('.ms-Breadcrumb-overflowButton');
+      let overflowMenu: JQuery = element.find('.ms-Breadcrumb-overflowMenu');
+      let body: JQuery = jQuery('body');
+
+      expect(overflowMenu).not.toHaveClass('is-open');
+
+      overflowButton.click();
+      scope.$digest();
+
+      expect(overflowMenu).toHaveClass('is-open');
+
+      body.click();
+      scope.$digest();
+
+      expect(overflowMenu).not.toHaveClass('is-open');
+    });
+
+    it('should change breadcrumb count on resize', inject(($window: ng.IWindowService) => {
+
+      let visibleLinks: JQuery = element.find('.ms-Breadcrumb-list li');
+      expect(visibleLinks.length === 4).toBeTruthy();
+
+      let overflowLinks: JQuery = element.find('.ms-ContextualMenu li');
+      expect(overflowLinks.length === 2).toBeTruthy();
+
+      // narrow down window
+      $window.innerWidth = 620; // must be less than breaking point
+      ng.element($window).triggerHandler('resize');
+      scope.$digest();
+
+      visibleLinks = element.find('.ms-Breadcrumb-list li');
+      expect(visibleLinks.length === 2).toBeTruthy();
+
+      overflowLinks = element.find('.ms-ContextualMenu li');
+      expect(overflowLinks.length === 4).toBeTruthy();
+
+      // back to normal
+      $window.innerWidth = 800; // must be less than breaking point
+      ng.element($window).triggerHandler('resize');
+      scope.$digest();
+
+      visibleLinks = element.find('.ms-Breadcrumb-list li');
+      expect(visibleLinks.length === 4).toBeTruthy();
+
+      overflowLinks = element.find('.ms-ContextualMenu li');
+      expect(overflowLinks.length === 2).toBeTruthy();
+
+      // set the same size again (for branch coverage ;))
+      ng.element($window).triggerHandler('resize');
+      scope.$digest();
+
+      visibleLinks = element.find('.ms-Breadcrumb-list li');
+      expect(visibleLinks.length === 4).toBeTruthy();
+
+      overflowLinks = element.find('.ms-ContextualMenu li');
+      expect(overflowLinks.length === 2).toBeTruthy();
+    }));
+
+  });
 });

--- a/src/components/breadcrumb/breadcrumbDirective.ts
+++ b/src/components/breadcrumb/breadcrumbDirective.ts
@@ -67,6 +67,48 @@ export class BreadcrumbLinkDirective implements ng.IDirective {
 }
 
 /**
+ * @ngdoc object
+ * @name BreadcrumbLink
+ * @module officeuifabric.components.breadcrumb
+ *
+ * @description
+ * Object defininf structure for breadcrumb links
+ *
+ * @property {string} href      - value for the href attribute for link
+ * @property {string} linkText  - text of the link
+ */
+export class BreadcrumbLink {
+  constructor(public href: string, public linkText: string) { }
+}
+
+/**
+ * @ngdoc interface
+ * @name IBreadcrumbScope
+ * @module officeuifabric.components.breadcrumb
+ *
+ * @description
+ * This is the scope used by uifBreadcrumb directive.
+ *
+ * @property {array} uifBreadcrumbLinks   - Collection of items to be rendered as breadcrumb elements.
+ * @property {number} visibleElements     - Number of breadcrumb items visible, based on screen width.
+ * @property {function} overflowElements  - Function returning number of elements that should be placed in overflow menu.
+ * @property {boolean} overflowMenuOpen   - Indicates whether overlfow menu is open or not.
+ * @property {function} openOverflow      - Handler for opening overflow menu.
+ * @property {function} isOverflow        - Function determining if thre are overflow elements.
+ *                                          Returns true if there are such elements, false otherwise.
+ */
+export interface IBreadcrumbScope extends ng.IScope {
+  uifBreadcrumbLinks: BreadcrumbLink[];
+  visibleElements: number;
+  overflowElements: () => number;
+
+  overflowMenuOpen: boolean;
+  openOverflow: (event: ng.IAngularEvent) => void;
+
+  isOverflow: () => boolean;
+}
+
+/**
  * @ngdoc class
  * @name BreadcrumbController
  * @module officeuifabric.components.breadcrumb
@@ -74,8 +116,46 @@ export class BreadcrumbLinkDirective implements ng.IDirective {
  * @description This is the controller for the breadcrumb component
  */
 export class BreadcrumbController {
-  public static $inject: string[] = ['$compile'];
-  constructor(public $compile: ng.ICompileService) {
+  public static $inject: string[] = ['$scope', '$document', '$window'];
+
+  private static _breakingWidth: number = 639;
+  constructor(public $scope: IBreadcrumbScope, public $document: ng.IDocumentService, public $window: ng.IWindowService) {
+    let windowElement: ng.IAugmentedJQuery = ng.element($window);
+
+    $scope.visibleElements = 4;
+    $scope.overflowMenuOpen = false;
+
+    $scope.isOverflow = () => {
+      let overflow: boolean = false;
+      overflow = ng.isDefined($scope.uifBreadcrumbLinks) && $scope.uifBreadcrumbLinks.length > $scope.visibleElements;
+      return overflow;
+    };
+
+    $scope.overflowElements = () => {
+      return $scope.isOverflow() ? $scope.uifBreadcrumbLinks.length - $scope.visibleElements : 0;
+    };
+
+    $scope.openOverflow = (event: ng.IAngularEvent) => {
+      event.stopPropagation();
+      $scope.overflowMenuOpen = true;
+
+    };
+
+    $document.find('html').on('click', (event: any) => {
+      $scope.overflowMenuOpen = false;
+      $scope.$apply();
+    });
+
+    windowElement.on('resize', () => {
+      let width: number = $window.innerWidth;
+
+      let elementsToShow: number = (width > BreadcrumbController._breakingWidth) ? 4 : 2;
+      if (elementsToShow !== $scope.visibleElements) {
+        $scope.visibleElements = elementsToShow;
+        $scope.$apply();
+      }
+
+    });
   }
 }
 
@@ -99,44 +179,38 @@ export class BreadcrumbController {
 
 export class BreadcrumbDirective implements ng.IDirective {
   public restrict: string = 'E';
-  public transclude: boolean = true;
   public replace: boolean = true;
   public template: string = '' +
-  '<div class="ms-Breadcrumb">' +
+  '<div class="ms-Breadcrumb" ng-class="{\'is-overflow\': isOverflow()}">' +
   '<div class="ms-Breadcrumb-overflow">' +
-  '<div class="ms-Breadcrumb-overflowButton ms-Icon ms-Icon--ellipsis" tabindex="1">' +
+  '<div class="ms-Breadcrumb-overflowButton ms-Icon ms-Icon--ellipsis" ng-click="openOverflow($event)" tabindex="1">' +
   '</div>' +
   '<i class="ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight"></i>' +
-  '<div class="ms-Breadcrumb-overflowMenu">' +
-  '<ul class="ms-ContextualMenu is-open"></ul>' +
+  '<div class="ms-Breadcrumb-overflowMenu" ng-class="{\'is-open\': overflowMenuOpen}">' +
+  '<ul class="ms-ContextualMenu is-open">' +
+    '<li class="ms-ContextualMenu-item" ' +
+    'ng-repeat="link in uifBreadcrumbLinks | limitTo:overflowElements()">' +
+    '<a class="ms-ContextualMenu-link" ng-href="{{link.href}}">{{link.linkText}}</a>' +
+    '</li>' +
+  '</ul>' +
   '</div>' +
   '</div>' +
   '<ul class="ms-Breadcrumb-list">' +
+  '<uif-breadcrumb-link ng-repeat="link in uifBreadcrumbLinks | limitTo:-visibleElements" ' +
+  'ng-href="{{link.href}}">{{link.linkText}}</uif-breadcrumb-link>' +
   '</ul>' +
   '</div>';
   public controller: typeof BreadcrumbController = BreadcrumbController;
   public require: string = 'uifBreadcrumb';
+  public scope: any = {
+    'uifBreadcrumbLinks': '='
+  };
 
   public static factory(): ng.IDirectiveFactory {
     const directive: ng.IDirectiveFactory = () => new BreadcrumbDirective();
     return directive;
   }
 
-  public link(
-    scope: ng.IScope,
-    instanceElement: ng.IAugmentedJQuery,
-    attributes: any,
-    ctrl: BreadcrumbController,
-    transclude: ng.ITranscludeFunction): void {
-
-    let ul: JQuery = ng.element(instanceElement[0].querySelector('.ms-Breadcrumb-list'));
-
-    transclude((transcludedElement: JQuery) => {
-      let breadcrumbLinks: JQuery = angular.element(transcludedElement);
-      ul.append(breadcrumbLinks);
-    });
-
-  }
 };
 
 /**

--- a/src/components/breadcrumb/demo/index.html
+++ b/src/components/breadcrumb/demo/index.html
@@ -16,7 +16,7 @@
   <script src="index.js"></script>
 </head>
 
-<body ng-app="demoApp">
+<body ng-app="demoApp" ng-controller="demoCtrl">
   <h1 class="ms-font-su">Breadcrumb Demo | &lt;uif-breadcrumb&gt;</h1>
   <em>In order for this demo to work you must first build the library in debug mode.</em>
 
@@ -24,30 +24,27 @@
   <p>To render breadcrumb, use the following markup:
     <br/>
     <pre>
-        &lt;uif-breadcrumb&gt;&#13;&#10;          &lt;uif-breadcrumb-link ng-href=&quot;\&apos;http://github1.com\&apos;&quot;&gt;GitHub1&lt;/uif-breadcrumb-link&gt;&#13;&#10;          &lt;uif-breadcrumb-link ng-href=&quot;\&apos;http://github2.com\&apos;&quot;&gt;GitHub2&lt;/uif-breadcrumb-link&gt;&#13;&#10;          &lt;uif-breadcrumb-link ng-href=&quot;\&apos;http://github3.com\&apos;&quot;&gt;GitHub3&lt;/uif-breadcrumb-link&gt;&#13;&#10;          &lt;uif-breadcrumb-link ng-href=&quot;\&apos;http://github4.com\&apos;&quot;&gt;GitHub4&lt;/uif-breadcrumb-link&gt;&#13;&#10;        &lt;/uif-breadcrumb&gt;
-      </pre>
-  </p>
-
-  <p>
-    <uif-breadcrumb>
-      <uif-breadcrumb-link ng-href="\'http://github1.com\'">GitHub1</uif-breadcrumb-link>
-      <uif-breadcrumb-link ng-href="\'http://github2.com\'">GitHub2</uif-breadcrumb-link>
-      <uif-breadcrumb-link ng-href="\'http://github3.com\'">GitHub3</uif-breadcrumb-link>
-      <uif-breadcrumb-link ng-href="\'http://github4.com\'">GitHub4</uif-breadcrumb-link>
-    </uif-breadcrumb>
-  </p>
-  <h2>ng-repeat</h2>
-  <p>
+      &lt;uif-breadcrumb uif-breadcrumb-links=&quot;links&quot;&gt;&lt;/uif-breadcrumb&gt;
+    </pre> Breadcrumb elements are passed as an expression to <em>uif-breadcrumb-links</em> attribute. Expression should
+    evaluate as an array of objects with following properties:
+    <ul>
+      <li><em>href</em></li>
+      <li><em>linkText</em></li>
+    </ul>
+    Sample array of such elements can be found below:
     <pre>
-      &lt;uif-breadcrumb&gt;
-      &lt;uif-breadcrumb-link ng-href=&quot;{{item}}&quot; ng-repeat=&quot;item in items&quot;&gt;{{item}}&lt;/uif-breadcrumb-link&gt;
-      &lt;/uif-breadcrumb&gt;
+      $scope.links = [
+        {href: 'http://github1.com', linkText: 'GitHub1'},
+        {href: 'http://github2.com', linkText: 'GitHub2'},
+        {href: 'http://github3.com', linkText: 'GitHub3'},
+        {href: 'http://github4.com', linkText: 'GitHub4'},
+        {href: 'http://github5.com', linkText: 'GitHub5'},
+        {href: 'http://github6.com', linkText: 'GitHub6'}
+      ];
     </pre>
   </p>
-  <p ng-controller="demoCtrl">
-    <uif-breadcrumb>
-      <uif-breadcrumb-link ng-href="{{item}}" ng-repeat="item in items">{{item}}</uif-breadcrumb-link>
-    </uif-breadcrumb>
+  <p>
+    <uif-breadcrumb uif-breadcrumb-links="links"></uif-breadcrumb>
   </p>
 </body>
 

--- a/src/components/breadcrumb/demo/index.js
+++ b/src/components/breadcrumb/demo/index.js
@@ -6,5 +6,12 @@ var demoApp = angular.module('demoApp', [
 ]);
 
 demoApp.controller('demoCtrl', ['$scope', function ($scope) {
-  $scope.items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+  $scope.links = [
+      {href: 'http://github1.com', linkText: 'GitHub1'},
+      {href: 'http://github2.com', linkText: 'GitHub2'},
+      {href: 'http://github3.com', linkText: 'GitHub3'},
+      {href: 'http://github4.com', linkText: 'GitHub4'},
+      {href: 'http://github5.com', linkText: 'GitHub5'},
+      {href: 'http://github6.com', linkText: 'GitHub6'}
+    ];
 }]);


### PR DESCRIPTION
Breaking changes:
- component does not allow transclusion of the `uif-breadcrumb-link` elements.
- breadcrumb items have to be passed as expression evaluating to an array of elements containing link text and href.

You have to convert your code from:

``` html
<uif-breadcrumb>
  <uif-breadcrumb-link ng-href="\'http://github1.com\'">GitHub1</uif-breadcrumb-link>
  <uif-breadcrumb-link ng-href="\'http://github2.com\'">GitHub2</uif-breadcrumb-link>
  <uif-breadcrumb-link ng-href="\'http://github3.com\'">GitHub3</uif-breadcrumb-link>
  <uif-breadcrumb-link ng-href="\'http://github4.com\'">GitHub4</uif-breadcrumb-link>
</uif-breadcrumb>
```

to this:

``` html
<uif-breadcrumb uif-breadcrumb-links="links"></uif-breadcrumb>
```

In your controller, you want to have defined array of breadcrumb items:

``` js
$scope.links = [
    {href: 'http://github1.com', linkText: 'GitHub1'},
    {href: 'http://github2.com', linkText: 'GitHub2'},
    {href: 'http://github3.com', linkText: 'GitHub3'},
    {href: 'http://github4.com', linkText: 'GitHub4'},
    {href: 'http://github5.com', linkText: 'GitHub5'},
    {href: 'http://github6.com', linkText: 'GitHub6'}
];
```

Added missing responsiveness to breadcrumb. Based on browser width, 4 or 2 last breadcrumb items are displayed.

Rest of the elements are placed in overflow menu, which is accessible via the ellipsis icon.
In order to add this feature, internal implementation has been changed as well as input of the elements to display.

Closes #342
