### PR TITLE
Fixed typo in git update process for dev and master branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Before doing anything, update your dev & master branches:
   git checkout dev
   git pull --rebase upstream dev
   git checkout master
-  get pull --rebase upstream master
+  git pull --rebase upstream master
   ```
 
 To update your folder for the Typings update...


### PR DESCRIPTION
Fixed Typo in changelog...

changed:
get pull --rebase upstream master

to:
git pull --rebase upstream master
