### PR TITLE
fix(panel): close button no longer triggers reload

### DIFF
--- a/src/components/panel/panelDirective.spec.ts
+++ b/src/components/panel/panelDirective.spec.ts
@@ -87,6 +87,12 @@ describe('panel: <uif-panel />', () => {
       expect($scope.isOpen).toEqual(false);
     }));
 
+    it('close button should not trigger submit', () => {
+      let closeButton: JQuery = panel.find('.ms-Panel-closeButton');
+      this.$timeoutservice.flush();
+      expect(closeButton).toHaveAttr('type', 'button');
+    });
+
   });
 
   describe('Command bar is placed correctly', () => {

--- a/src/components/panel/panelDirective.ts
+++ b/src/components/panel/panelDirective.ts
@@ -27,7 +27,7 @@ export class PanelDirective implements ng.IDirective {
                                     ng-class="uifShowOverlay === true ? \'ms-Overlay--dark\' : \'\';"></div>
                               <div class="ms-Panel-main">
                                 <div class="ms-Panel-commands">
-                                  <button ng-if="uifShowClose" class='ms-Panel-closeButton' ng-click="closePanel()">
+                                  <button type="button" ng-if="uifShowClose" class='ms-Panel-closeButton' ng-click="closePanel()">
                                     <uif-icon uif-type='x'></uif-icon>
                                   </button>
                                 </div>


### PR DESCRIPTION
Added `type=button` attribute to uifPanel close button to prevent default submit behavior of the button.

Closes #366.
