### PR TITLE
fix(textfield): $dirty not being set on uif-textfield

### DIFF
--- a/src/components/textfield/dirtyDemo/index.html
+++ b/src/components/textfield/dirtyDemo/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script data-require="angularjs@1.5.5" data-semver="1.5.5" src="https://code.angularjs.org/1.5.5/angular.js"></script>
+  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.0/fabric.min.css">
+  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.0/fabric.components.min.css">
+  <script src="../../../../dist/ngOfficeUiFabric.js"></script>
+</head>
+
+<body ng-app="app" ng-controller="AppController as vm">
+  <h1>Dirty Checking with ngOfficeUiFabric directives</h1>
+
+
+  <form name="dirtyForm" novalidate>
+
+    <!--<input type="text" name="working" ng-model="vm.working" />-->
+
+    <uif-textfield name="notworking" uif-description="This is the description" uif-label="This is the label" ng-model="vm.notWorking"></uif-textfield>
+
+    <pre> {{ dirtyForm | json }}</pre>
+
+  </form>
+
+
+
+  <script>
+    angular.module('app', ['officeuifabric.core', 'officeuifabric.components', ]);
+
+    angular.module('app').controller('AppController', ['$scope', function() {
+      var vm = this;
+
+      vm.notWorking = "not working";
+      vm.working = "standard input element";
+
+
+    }]);
+  </script>
+</body>
+
+</html>

--- a/src/components/textfield/textFieldDirective.spec.ts
+++ b/src/components/textfield/textFieldDirective.spec.ts
@@ -250,4 +250,49 @@ describe('textFieldDirective: <uif-textfield />', () => {
         label.click();
         expect(input[0].focus).toHaveBeenCalled();
     }));
+
+    it('changing text field should set $dirty on model', inject(($compile: ng.ICompileService, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        $scope.modelValue = 'test';
+
+        let liteTextBox: ng.IAugmentedJQuery =
+            $compile('<uif-textfield ng-model="modelValue" placeholder="Placeholder contents"></uif-textfield>')($scope);
+        let textBox: JQuery = jQuery(liteTextBox[0]);
+        $scope.$digest();
+
+        let input: JQuery = textBox.find('input.ms-TextField-field');
+        input = jQuery(input);
+
+        let ngModelCtrl: ng.INgModelController = angular.element(textBox).controller('ngModel');
+        expect(ngModelCtrl.$dirty).toBe(false);
+
+        input.val('xyz');
+        angular.element(input).triggerHandler('input');
+
+        $scope.$digest();
+
+        expect(ngModelCtrl.$dirty).toBe(true);
+    }));
+
+    it('defocusing text field sets $touched on model', inject(($compile: ng.ICompileService, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        $scope.modelValue = 'test';
+        let liteTextBox: ng.IAugmentedJQuery =
+                $compile('<uif-textfield ng-model="modelValue" placeholder="Placeholder contents"></uif-textfield>')($scope);
+
+        let textBox: JQuery = jQuery(liteTextBox[0]);
+        $scope.$digest();
+
+        let input: JQuery = textBox.find('input.ms-TextField-field');
+        input = jQuery(input);
+
+        let ngModelCtrl: ng.INgModelController = angular.element(textBox).controller('ngModel');
+        expect(ngModelCtrl.$touched).toBe(false);
+
+        angular.element(input).triggerHandler('blur');
+
+        $scope.$digest();
+
+        expect(ngModelCtrl.$touched).toBe(true);
+    }));
 });

--- a/src/components/textfield/textFieldDirective.ts
+++ b/src/components/textfield/textFieldDirective.ts
@@ -38,6 +38,7 @@ export interface ITextFieldScope extends ng.IScope {
   uifUnderlined: boolean;
   inputFocus: (ev: any) => void;
   inputBlur: (ev: any) => void;
+  inputChange: (ev: any) => void;
   labelClick: (ev: any) => void;
   isActive: boolean;
   required: boolean;
@@ -101,7 +102,7 @@ export class TextFieldDirective implements ng.IDirective {
   '\'ms-TextField--underlined\': uifUnderlined, \'ms-TextField--placeholder\': placeholder, ' +
   '\'is-required\': required, \'is-disabled\': disabled, \'ms-TextField--multiline\' : uifMultiline }">' +
   '<label ng-show="labelShown" class="ms-Label" ng-click="labelClick()">{{uifLabel || placeholder}}</label>' +
-  '<input ng-model="ngModel" ng-change="ngChange" ng-blur="inputBlur()" ng-focus="inputFocus()" ng-click="inputClick()" ' +
+  '<input ng-model="ngModel" ng-change="inputChange()" ng-blur="inputBlur()" ng-focus="inputFocus()" ng-click="inputClick()" ' +
   'class="ms-TextField-field" ng-show="!uifMultiline" ng-disabled="disabled" type="{{uifType}}"' +
   'min="{{min}}" max="{{max}}" step="{{step}}" />' +
   '<textarea ng-model="ngModel" ng-blur="inputBlur()" ng-focus="inputFocus()" ng-click="inputClick()" ' +
@@ -174,12 +175,22 @@ export class TextFieldDirective implements ng.IDirective {
         scope.labelShown = true;
       }
       scope.isActive = false;
+
+      if (ng.isDefined(ngModel) && ngModel != null) {
+        ngModel.$setTouched();
+      }
     };
     scope.labelClick = function (ev: any): void {
       if (scope.placeholder) {
         let input: JQuery = scope.uifMultiline ? instanceElement.find('textarea')
           : instanceElement.find('input');
         input[0].focus();
+      }
+    };
+
+    scope.inputChange = function (ev: any): void {
+      if (ng.isDefined(ngModel) && ngModel != null) {
+        ngModel.$setDirty();
       }
     };
 


### PR DESCRIPTION
Added support for `ngModel.$dity` & `ngModel.$touched` for `uif-textfield`.

Added support for `$dirty` & `$touched` properties on `uif-textfield` by hooking into underlying input element events. This improves experience of using `uif-textfield` with forms.

Closes #367
