### PR TITLE
fix(dropdown): $dirty not being set on uif-dropdown

### DIFF
--- a/src/components/dropdown/dirtyDemo/index.html
+++ b/src/components/dropdown/dirtyDemo/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script data-require="angularjs@1.5.5" data-semver="1.5.5" src="https://code.angularjs.org/1.5.5/angular.js"></script>
+  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.0/fabric.min.css">
+  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.0/fabric.components.min.css">
+  <script src="../../../../dist/ngOfficeUiFabric.js"></script>
+</head>
+
+<body ng-app="app" ng-controller="AppController as vm">
+<form name="dirtyForm" novalidate>
+
+    <!--<input type="text" name="working" ng-model="vm.working" />-->
+
+    <uif-dropdown ng-model="vm.dropdown" name="dropdown">
+      <uif-dropdown-option value="value1">Value 1</uif-dropdown-option>
+      <uif-dropdown-option value="value2">Value 2</uif-dropdown-option>
+      <uif-dropdown-option value="value3">Value 3</uif-dropdown-option>
+      <uif-dropdown-option value="value4">Value 4</uif-dropdown-option>
+    </uif-dropdown>
+
+    <pre> {{ dirtyForm | json }}</pre>
+
+  </form>
+
+  <script>
+    angular.module('app', ['officeuifabric.core', 'officeuifabric.components', ]);
+
+    angular.module('app').controller('AppController', ['$scope', function() {
+      var vm = this;
+
+      vm.dropdown = "value2";
+
+    }]);
+  </script>
+</body>
+
+</html>

--- a/src/components/dropdown/dropdownDirective.spec.ts
+++ b/src/components/dropdown/dropdownDirective.spec.ts
@@ -191,4 +191,59 @@
         let title: JQuery = dropdown.find('span.ms-Dropdown-title');
         expect(title.text()).toBe('Option 2', 'Displayed text should be Option 2');
     }));
+
+    it('should set $touched on blur', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        $scope.options = [
+            { text: 'Option 1', value: 'Option1'},
+            { text: 'Option 2', value: 'Option2'},
+            { text: 'Option 3', value: 'Option3'},
+            { text: 'Option 4', value: 'Option4'}
+        ];
+        $scope.selectedValue = 'Option2';
+
+        let liteDropdown: ng.IAugmentedJQuery = $compile('<uif-dropdown ng-model="selectedValue">' +
+            '<uif-dropdown-option ng-repeat="option in options" value="{{option.value}}"\
+              title="{{option.text}}">{{option.text}}</uif-dropdown-option>' +
+            '</uif-dropdown>')($scope);
+        $scope.$digest();
+        let dropdown: JQuery = jQuery(liteDropdown[0]);
+
+        let ngModelCtrl: ng.INgModelController = angular.element(liteDropdown).controller('ngModel');
+        expect(ngModelCtrl.$touched).toBe(false);
+
+        dropdown.click();
+        $('html').click();
+
+        $scope.$digest();
+
+        expect(ngModelCtrl.$touched).toBe(true);
+    }));
+
+    it('should set $dirty on value change', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        $scope.options = [
+            { text: 'Option 1', value: 'Option1'},
+            { text: 'Option 2', value: 'Option2'},
+            { text: 'Option 3', value: 'Option3'},
+            { text: 'Option 4', value: 'Option4'}
+        ];
+        $scope.selectedValue = 'Option2';
+
+        let liteDropdown: ng.IAugmentedJQuery = $compile('<uif-dropdown ng-model="selectedValue">' +
+            '<uif-dropdown-option ng-repeat="option in options" value="{{option.value}}"\
+              title="{{option.text}}">{{option.text}}</uif-dropdown-option>' +
+            '</uif-dropdown>')($scope);
+        $scope.$digest();
+        let dropdown: JQuery = jQuery(liteDropdown[0]);
+
+        let ngModelCtrl: ng.INgModelController = angular.element(liteDropdown).controller('ngModel');
+        expect(ngModelCtrl.$dirty).toBe(false);
+
+        let option3: JQuery = jQuery(dropdown.find('li')[2]);
+        option3.click();
+        expect($scope.selectedValue).toBe('Option3', 'Selected value should be Option3');
+
+        expect(ngModelCtrl.$dirty).toBe(true);
+    }));
 });

--- a/src/components/dropdown/dropdownDirective.ts
+++ b/src/components/dropdown/dropdownDirective.ts
@@ -116,6 +116,9 @@ export class DropdownController {
                         self.$document.off('click', documentClickHandler);
                     });
                 }
+                if(self.$scope.ngModel !== undefined && self.$scope.ngModel != null) {
+                    self.$scope.ngModel.$setTouched();
+                }
             }
         });
         if (typeof this.$scope.ngModel !== 'undefined'  && this.$scope.ngModel != null) {


### PR DESCRIPTION
Added support `$touched` property on `uif-dropdown` by hooking into underlying click definition.
Also added test cases for verification if `$touched` & `$dirty` are being set correctly on the `ngModel`.

Closes #368
