### PR TITLE
fix(toogle): $dirty not being set on uif-toggle

### DIFF
--- a/src/components/toggle/demoDirty/index.html
+++ b/src/components/toggle/demoDirty/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script data-require="angularjs@1.5.5" data-semver="1.5.5" src="https://code.angularjs.org/1.5.5/angular.js"></script>
+  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.0/fabric.min.css">
+  <link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/1.0/fabric.components.min.css">
+  <script src="../../../../dist/ngOfficeUiFabric.js"></script>
+</head>
+
+<body ng-app="app" ng-controller="AppController as vm">
+<h1>Dirty Checking with ngOfficeUiFabric directives</h1>
+
+  <form name="dirtyForm" novalidate>
+
+    <input type="text" name="working" ng-model="vm.working" />
+
+    <uif-toggle name="notworking" uif-label-off="Label off" uif-label-on="Label on" ng-model="vm.notWorking"></uif-toggle>
+
+    <pre> {{ dirtyForm | json }}</pre>
+
+  </form>
+
+  <script>
+    angular.module('app', ['officeuifabric.core', 'officeuifabric.components', ]);
+
+    angular.module('app').controller('AppController', ['$scope', function() {
+      var vm = this;
+
+      vm.notWorking = true;
+      vm.working = "standard input element";
+    }]);
+  </script>
+</body>
+
+</html>

--- a/src/components/toggle/toggleDirective.spec.ts
+++ b/src/components/toggle/toggleDirective.spec.ts
@@ -152,4 +152,28 @@ describe('toggleDirective: <uif-toggle />', () => {
 
         expect(input.attr('ng-false-value') === undefined).toBe(true);
     }));
+
+    it('should set $dirty when value changed', inject(($compile: Function, $rootScope: ng.IRootScopeService) => {
+        let $scope: any = $rootScope.$new();
+        $scope.toggled = true;
+
+        let toggle: JQuery = $compile('<uif-toggle uif-label-off="No" uif-label-on="Yes" ng-model="toggled"></toggle>')($scope);
+        toggle = jQuery(toggle[0]);
+        $scope.$apply();
+
+        let checkBox: JQuery = toggle.find('input.ms-Toggle-input');
+
+        let ngModel: ng.INgModelController = angular.element(toggle).controller('ngModel');
+
+        expect(ngModel.$dirty).toBe(false);
+        expect(ngModel.$touched).toBe(false);
+
+        checkBox.click();
+        $scope.$apply();
+
+        expect($scope.toggled).toBe(false);
+
+        expect(ngModel.$dirty).toBe(true);
+        expect(ngModel.$touched).toBe(true);
+    }));
 });

--- a/src/components/toggle/toggleDirective.ts
+++ b/src/components/toggle/toggleDirective.ts
@@ -6,15 +6,15 @@ import * as ng from 'angular';
  * @ngdoc interface
  * @name IToggleScope
  * @module officeuifabric.components.toggle
- * 
- * @description 
- * This is the scope used by the directive. 
- *  
- * 
+ *
+ * @description
+ * This is the scope used by the directive.
+ *
+ *
  * @property {string} ngModel         - The scope variable to bind to the toggle.
  * @property {string} uifLabelOff     - The label to display when not toggled
  * @property {string} uifLabelOn      - The label to display when toggled
- * @property {string} uifTextLocation - Location of the label (left or right), compared to the toggle  
+ * @property {string} uifTextLocation - Location of the label (left or right), compared to the toggle
  * @property {string} uniqueId
  * @property {string} textLocation
  * @property {string} disabled
@@ -34,29 +34,30 @@ export interface IToggleScope extends ng.IScope {
     ngChange: string;
     ngTrueValue: string;
     ngFalseValue: string;
+    checkboxChange: () => void;
 }
 
 /**
  * @ngdoc directive
  * @name uifToggle
  * @module officeuifabric.components.toggle
- * 
+ *
  * @restrict E
- * 
- * @description 
+ *
+ * @description
  * `<uif-toggle>` is a toggle directive.
- * 
+ *
  * @see {link http://officeuifabric.com/components/toggle/}
- * 
+ *
  * @usage
- * 
+ *
  * <uif-toggle ng-model='toggled' />
  */
 export class ToggleDirective implements ng.IDirective {
     public template: string = '<div ng-class="[\'ms-Toggle\', textLocation, {\'is-disabled\': disabled}]">' +
                  '<span class="ms-Toggle-description"><ng-transclude/></span>' +
                 '<input type="checkbox" id="{{::$id}}" class="ms-Toggle-input" ' +
-                'ng-model="ngModel" ng-change="ngChange()" ng-disabled="disabled" ' +
+                'ng-model="ngModel" ng-change="checkboxChange();ngChange()" ng-disabled="disabled" ' +
                 'ng-attr-ng-true-value="{{ngTrueValue || undefined}}" ng-attr-ng-false-value="{{ngFalseValue || undefined}}" />' +
                 '<label for="{{::$id}}" class="ms-Toggle-field">' +
                     '<span class="ms-Label ms-Label--off">{{uifLabelOff}}</span>' +
@@ -65,6 +66,7 @@ export class ToggleDirective implements ng.IDirective {
                 '</div>';
     public restrict: string = 'E';
     public transclude: boolean = true;
+    public require: string[] = ['?ngModel'];
     public scope: {} = {
         ngChange: '&?',
         ngFalseValue: '@?',
@@ -80,7 +82,12 @@ export class ToggleDirective implements ng.IDirective {
         return directive;
     }
 
-    public link(scope: IToggleScope, elem: ng.IAugmentedJQuery, attrs: ng.IAttributes): void {
+    public link(scope: IToggleScope, elem: ng.IAugmentedJQuery, attrs: ng.IAttributes, ctrls: any[]): void {
+        let ngModelCtrl: ng.INgModelController;
+        if (ng.isDefined(ctrls) && ctrls.length > 0) {
+            ngModelCtrl = ctrls[0];
+        }
+
         if (scope.uifTextLocation) {
             let loc: string = scope.uifTextLocation;
             loc = loc.charAt(0).toUpperCase() + loc.slice(1);
@@ -91,16 +98,23 @@ export class ToggleDirective implements ng.IDirective {
             ((newValue) => { scope.disabled = typeof newValue !== 'undefined'; })
         );
         scope.disabled = 'disabled' in attrs;
+
+        scope.checkboxChange = () => {
+            if (ng.isDefined(ngModelCtrl) && ngModelCtrl  !== null) {
+                ngModelCtrl.$setDirty();
+                ngModelCtrl.$setTouched();
+            }
+        };
     }
 }
 
 /**
  * @ngdoc module
  * @name officeuifabric.components.toggle
- * 
- * @description 
+ *
+ * @description
  * Toggle
- * 
+ *
  */
 export var module: ng.IModule = ng.module('officeuifabric.components.toggle', [
     'officeuifabric.components'


### PR DESCRIPTION
Added support for $dirty & $touched properties of `ngModel` for uif-toggle component.

Added support for $dirty & $touched properties of `ngModel` for uif-toggle component.
Both properites are set from the internal checkbox `ng-change` handler, as `blur` event does not occur for the toggle.

Closes #379
