### PR TITLE
The documentaion for searchbox contained an error

### DIFF
--- a/src/components/searchbox/demo/index.html
+++ b/src/components/searchbox/demo/index.html
@@ -21,7 +21,7 @@
     <em>In order for this demo to work you must first build the library in debug mode.</em>
 
     <p>
-        Use the attributes <code>uif-value</code> to specify the value of the search field.
+        Use the attributes <code>value</code> to specify the value of the search field.
     </p>
     <p>
         Use the attributes <code>placeholder</code> to specify the placeholder of the search field.


### PR DESCRIPTION
Closes #413
In the documentation for searchbox, it said to use the `uif-value` attribute to specify the value of the search field, when in fact it was just `value`.
