### PR TITLE
Fix breadcrumb resizing testability

### DIFF
--- a/build/gulp/tasks/test.ts
+++ b/build/gulp/tasks/test.ts
@@ -1,8 +1,8 @@
 'use strict';
 
-import {BaseGulpTask} from '../BaseGulpTask';
-import {Utils} from '../utils';
-import {BuildConfig} from '../../config/build';
+import { BaseGulpTask } from '../BaseGulpTask';
+import { Utils } from '../utils';
+import { BuildConfig } from '../../config/build';
 import * as yargs from 'yargs';
 import * as karma from 'karma';
 import * as gulp from 'gulp';
@@ -94,11 +94,12 @@ export class GulpTask extends BaseGulpTask {
       Utils.log('Karma test run completed');
 
       // result = 1 means karma exited with error
-      if (karmaResult === 1) {
+      if (karmaResult !== 0) {
         Utils.log('Karma finished with error(s)');
+        done(() => { return new Error('Karma finished with errors'); });
+      } else {
+        done();
       }
-
-      done();
 
     });
     karmaServer.start();

--- a/src/components/breadcrumb/breadcrumbDirective.spec.ts
+++ b/src/components/breadcrumb/breadcrumbDirective.spec.ts
@@ -2,7 +2,7 @@
 
 import * as ng from 'angular';
 
-describe('breadcrumbDirective <uif-breadcrumb />', () => {
+describe('breadcrumb: <uif-breadcrumb />', () => {
   let element: JQuery;
   let scope: any;
 
@@ -14,86 +14,98 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
     angular.mock.module('officeuifabric.components.breadcrumb');
   });
 
-  beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: Function, $window: ng.IWindowService) => {
+  describe('browser width>=800px', () => {
 
-    $window.resizeTo(800, $window.innerWidth);
+    beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: Function, $window: ng.IWindowService) => {
+      let html: string = '<uif-breadcrumb uif-breadcrumb-links="breadcrumbLinks"></uif-breadcrumb>';
+      scope = $rootScope;
+      scope.breadcrumbLinks = [
+        { href: 'http://ngofficeuifabric.com/1', linkText: 'ngOfficeUiFabric-1' },
+        { href: 'http://ngofficeuifabric.com/2', linkText: 'ngOfficeUiFabric-2' },
+        { href: 'http://ngofficeuifabric.com/3', linkText: 'ngOfficeUiFabric-3' },
+        { href: 'http://ngofficeuifabric.com/4', linkText: 'ngOfficeUiFabric-4' }
+      ];
 
-    let html: string = '<uif-breadcrumb uif-breadcrumb-links="breadcrumbLinks"></uif-breadcrumb>';
-    scope = $rootScope;
-    scope.breadcrumbLinks = [
-      {href: 'http://ngofficeuifabric.com/1', linkText: 'ngOfficeUiFabric-1'},
-      {href: 'http://ngofficeuifabric.com/2', linkText: 'ngOfficeUiFabric-2'},
-      {href: 'http://ngofficeuifabric.com/3', linkText: 'ngOfficeUiFabric-3'},
-      {href: 'http://ngofficeuifabric.com/4', linkText: 'ngOfficeUiFabric-4'}
-    ];
+      element = $compile(html)(scope);    // jqLite object
+      element = jQuery(element[0]);       // jQuery object
 
-    element = $compile(html)(scope);    // jqLite object
-    element = jQuery(element[0]);       // jQuery object
+      scope.$digest();
+    }));
 
-    scope.$digest();
-  }));
+    it('should not have is-overflow class', () => {
+      // get the element scope
+      let directiveScope: any = ng.element(element).isolateScope();
+      // force recalculation on size
+      directiveScope.onResize(800);
 
-  it('should not have is-overflow class', () => {
-    expect(element).not.toHaveClass('is-overflow');
+      scope.$digest();
+
+      expect(element).not.toHaveClass('is-overflow');
+    });
+
+    it('should create correct HTML', () => {
+      // get the element scope
+      let directiveScope: any = ng.element(element).isolateScope();
+      // force recalculation on size
+      directiveScope.onResize(800);
+
+      // verify top breadcrumb container & correct style
+      expect(element.prop('tagName')).toEqual('DIV');
+      expect(element[0]).toHaveClass('ms-Breadcrumb');
+
+      // verify nested should contain UL
+      expect(element.find('ul').length).toBe(2);
+      let ulElement: JQuery = element.find('ul');
+      expect(ulElement[1]).toHaveClass('ms-Breadcrumb-list');
+
+      // look at all list items...
+      // ... get all list items...
+      let liElements: JQuery = ulElement.find('li');
+      // ... make sure there are 4 of them
+      expect(liElements.length).toBe(4, 'should only 4 list items present');
+
+      // loop through all list items...
+      for (let itemIndex: number = 0; itemIndex < liElements.length; itemIndex++) {
+        // for the list item...
+        let liElement: JQuery = $(liElements.get(itemIndex));
+
+        // make sure it has correct css
+        expect(liElement[0]).toHaveClass('ms-Breadcrumb-listItem');
+
+        // make sure it has exactly 1 nested link...
+        expect(liElement.find('a').length).toBe(1, 'expected to find exactly 1 <a> element');
+        let aElement: JQuery = liElement.find('a');
+        // ... with correct style...
+        expect(aElement[0]).toHaveClass('ms-Breadcrumb-itemLink');
+        // ... with correct target...
+        expect(aElement[0]).toHaveAttr('href', `http://ngofficeuifabric.com/${itemIndex + 1}`);
+        // ... with correct value...
+        expect(aElement[0].innerText).toBe(`ngOfficeUiFabric-${itemIndex + 1}`);
+
+        // make sure it has exactly 1 cheveron icon...
+        let iElement: JQuery = liElement.find('i');
+        expect(iElement.length).toBe(1);
+        // ... with correct styles...
+        expect(iElement[0]).toHaveClass('ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight');
+      }
+
+    });
   });
 
-  it('should create correct HTML', () => {
-    // verify top breadcrumb container & correct style
-    expect(element.prop('tagName')).toEqual('DIV');
-    expect(element[0]).toHaveClass('ms-Breadcrumb');
 
-    // verify nested should contain UL
-    expect(element.find('ul').length).toBe(2);
-    let ulElement: JQuery = element.find('ul');
-    expect(ulElement[1]).toHaveClass('ms-Breadcrumb-list');
+  describe('responsive breadcrumb', () => {
 
-    // look at all list items...
-    // ... get all list items...
-    let liElements: JQuery = ulElement.find('li');
-    // ... make sure there are 4 of them
-    expect(liElements.length).toBe(4, 'should only 4 list items present');
-
-    // loop through all list items...
-    for (let itemIndex: number = 0; itemIndex < liElements.length; itemIndex++) {
-      // for the list item...
-      let liElement: JQuery = $(liElements.get(itemIndex));
-
-      // make sure it has correct css
-      expect(liElement[0]).toHaveClass('ms-Breadcrumb-listItem');
-
-      // make sure it has exactly 1 nested link...
-      expect(liElement.find('a').length).toBe(1, 'expected to find exactly 1 <a> element');
-      let aElement: JQuery = liElement.find('a');
-      // ... with correct style...
-      expect(aElement[0]).toHaveClass('ms-Breadcrumb-itemLink');
-      // ... with correct tabindex...
-      expect(aElement[0]).toHaveAttr('tabindex', `${itemIndex + 2}`);
-      // ... with correct target...
-      expect(aElement[0]).toHaveAttr('href', `http://ngofficeuifabric.com/${itemIndex + 1}`);
-      // ... with correct value...
-      expect(aElement[0].innerText).toBe(`ngOfficeUiFabric-${itemIndex + 1}`);
-
-      // make sure it has exactly 1 cheveron icon...
-      let iElement: JQuery = liElement.find('i');
-      expect(iElement.length).toBe(1);
-      // ... with correct styles...
-      expect(iElement[0]).toHaveClass('ms-Breadcrumb-chevron ms-Icon ms-Icon--chevronRight');
-    }
-
-  });
-
-  describe('responsive breadCrumb', () => {
     beforeEach(inject(($rootScope: ng.IRootScopeService, $compile: ng.ICompileService) => {
 
       let html: string = '<uif-breadcrumb uif-breadcrumb-links="breadcrumbLinks"></uif-breadcrumb>';
       scope = $rootScope.$new();
       scope.breadcrumbLinks = [
-        {href: 'http://ngofficeuifabric.com/1', linkText: 'ngOfficeUiFabric-1'},
-        {href: 'http://ngofficeuifabric.com/2', linkText: 'ngOfficeUiFabric-2'},
-        {href: 'http://ngofficeuifabric.com/3', linkText: 'ngOfficeUiFabric-3'},
-        {href: 'http://ngofficeuifabric.com/4', linkText: 'ngOfficeUiFabric-4'},
-        {href: 'http://ngofficeuifabric.com/5', linkText: 'ngOfficeUiFabric-5'},
-        {href: 'http://ngofficeuifabric.com/6', linkText: 'ngOfficeUiFabric-6'}
+        { href: 'http://ngofficeuifabric.com/1', linkText: 'ngOfficeUiFabric-1' },
+        { href: 'http://ngofficeuifabric.com/2', linkText: 'ngOfficeUiFabric-2' },
+        { href: 'http://ngofficeuifabric.com/3', linkText: 'ngOfficeUiFabric-3' },
+        { href: 'http://ngofficeuifabric.com/4', linkText: 'ngOfficeUiFabric-4' },
+        { href: 'http://ngofficeuifabric.com/5', linkText: 'ngOfficeUiFabric-5' },
+        { href: 'http://ngofficeuifabric.com/6', linkText: 'ngOfficeUiFabric-6' }
       ];
 
       element = $compile(html)(scope);    // jqLite object
@@ -103,10 +115,14 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
     }));
 
     it('large screen: max 4 items should be visible', () => {
+      // get the element scope
+      let directiveScope: any = ng.element(element).isolateScope();
+      // force recalculation on size
+      directiveScope.onResize(800);
 
       let visibleLinks: JQuery = element.find('.ms-Breadcrumb-list li');
 
-      expect(visibleLinks.length === 4).toBeTruthy();
+      expect(visibleLinks.length).toBe(4);
 
       let firstLink: JQuery = visibleLinks.eq(0).find('a');
       expect(firstLink).toHaveAttr('href', 'http://ngofficeuifabric.com/3');
@@ -116,10 +132,14 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
     });
 
     it('large screen: max 2 items should be in contextual menu', () => {
+      // get the element scope
+      let directiveScope: any = ng.element(element).isolateScope();
+      // force recalculation on size
+      directiveScope.onResize(800);
 
       let overflowLinks: JQuery = element.find('.ms-ContextualMenu li');
 
-      expect(overflowLinks.length === 2).toBeTruthy();
+      expect(overflowLinks.length).toBe(2);
 
       let firstLink: JQuery = overflowLinks.eq(0).find('a');
       expect(firstLink).toHaveAttr('href', 'http://ngofficeuifabric.com/1');
@@ -154,73 +174,64 @@ describe('breadcrumbDirective <uif-breadcrumb />', () => {
       'should display 2 on small screen initially',
       inject(($rootScope: ng.IRootScopeService, $compile: ng.ICompileService, $window: ng.IWindowService
       ) => {
+        // get the element scope
+        let directiveScope: any = ng.element(element).isolateScope();
+        // set size to just under breaker & force recalculation on size
+        directiveScope.onResize(620);
 
-      $window.resizeTo(620, $window.innerWidth); // must be less than breaking point
+        let html: string = '<uif-breadcrumb uif-breadcrumb-links="breadcrumbLinks"></uif-breadcrumb>';
+        scope = $rootScope.$new();
+        scope.breadcrumbLinks = [
+          { href: 'http://ngofficeuifabric.com/1', linkText: 'ngOfficeUiFabric-1' },
+          { href: 'http://ngofficeuifabric.com/2', linkText: 'ngOfficeUiFabric-2' },
+          { href: 'http://ngofficeuifabric.com/3', linkText: 'ngOfficeUiFabric-3' },
+          { href: 'http://ngofficeuifabric.com/4', linkText: 'ngOfficeUiFabric-4' },
+          { href: 'http://ngofficeuifabric.com/5', linkText: 'ngOfficeUiFabric-5' },
+          { href: 'http://ngofficeuifabric.com/6', linkText: 'ngOfficeUiFabric-6' }
+        ];
 
-      let html: string = '<uif-breadcrumb uif-breadcrumb-links="breadcrumbLinks"></uif-breadcrumb>';
-      scope = $rootScope.$new();
-      scope.breadcrumbLinks = [
-        {href: 'http://ngofficeuifabric.com/1', linkText: 'ngOfficeUiFabric-1'},
-        {href: 'http://ngofficeuifabric.com/2', linkText: 'ngOfficeUiFabric-2'},
-        {href: 'http://ngofficeuifabric.com/3', linkText: 'ngOfficeUiFabric-3'},
-        {href: 'http://ngofficeuifabric.com/4', linkText: 'ngOfficeUiFabric-4'},
-        {href: 'http://ngofficeuifabric.com/5', linkText: 'ngOfficeUiFabric-5'},
-        {href: 'http://ngofficeuifabric.com/6', linkText: 'ngOfficeUiFabric-6'}
-      ];
+        element = $compile(html)(scope);    // jqLite object
+        element = jQuery(element[0]);       // jQuery object
 
-      element = $compile(html)(scope);    // jqLite object
-      element = jQuery(element[0]);       // jQuery object
+        scope.$digest();
 
-      scope.$digest();
+        let visibleLinks: JQuery = element.find('.ms-Breadcrumb-list li');
+        expect(visibleLinks.length).toBe(2);
 
-      let visibleLinks: JQuery = element.find('.ms-Breadcrumb-list li');
-      expect(visibleLinks.length === 2).toBeTruthy();
-
-      let overflowLinks: JQuery = element.find('.ms-ContextualMenu li');
-      expect(overflowLinks.length === 4).toBeTruthy();
-
-
-    }));
+        let overflowLinks: JQuery = element.find('.ms-ContextualMenu li');
+        expect(overflowLinks.length).toBe(4);
+      }));
 
     it('should change breadcrumb count on resize', inject(($window: ng.IWindowService) => {
+      // get the element scope
+      let directiveScope: any = ng.element(element).isolateScope();
+
+      // start with normal size
+      directiveScope.onResize(800);
 
       let visibleLinks: JQuery = element.find('.ms-Breadcrumb-list li');
-      expect(visibleLinks.length === 4).toBeTruthy();
+      expect(visibleLinks.length).toBe(4);
 
       let overflowLinks: JQuery = element.find('.ms-ContextualMenu li');
-      expect(overflowLinks.length === 2).toBeTruthy();
+      expect(overflowLinks.length).toBe(2);
 
       // narrow down window
-      $window.resizeTo(620, $window.innerWidth); // must be less than breaking point
-      ng.element($window).triggerHandler('resize');
-      scope.$digest();
+      directiveScope.onResize(620);
 
       visibleLinks = element.find('.ms-Breadcrumb-list li');
-      expect(visibleLinks.length === 2).toBeTruthy();
+      expect(visibleLinks.length).toBe(2);
 
       overflowLinks = element.find('.ms-ContextualMenu li');
-      expect(overflowLinks.length === 4).toBeTruthy();
+      expect(overflowLinks.length).toBe(4);
 
       // back to normal
-      $window.resizeTo(800, $window.innerWidth); // must be less than breaking point
-      ng.element($window).triggerHandler('resize');
-      scope.$digest();
+      directiveScope.onResize(800);
 
       visibleLinks = element.find('.ms-Breadcrumb-list li');
-      expect(visibleLinks.length === 4).toBeTruthy();
+      expect(visibleLinks.length).toBe(4);
 
       overflowLinks = element.find('.ms-ContextualMenu li');
-      expect(overflowLinks.length === 2).toBeTruthy();
-
-      // set the same size again (for branch coverage ;))
-      ng.element($window).triggerHandler('resize');
-      scope.$digest();
-
-      visibleLinks = element.find('.ms-Breadcrumb-list li');
-      expect(visibleLinks.length === 4).toBeTruthy();
-
-      overflowLinks = element.find('.ms-ContextualMenu li');
-      expect(overflowLinks.length === 2).toBeTruthy();
+      expect(overflowLinks.length).toBe(2);
     }));
 
   });


### PR DESCRIPTION
When submitting a pull request, make sure you do the following:
- [x] submit the PR to the `dev` branch on the main repo, **not** the `master` branch
- [x] include a brief description what the PR is for in the subject
- [x] in the body, explain what the PR addresses
- [x] in the body, reference the issue that it closes by number in the format `Closes #000.`
- [x] squash multiple commits into one and use good commit messages (https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/docs/guides/CODING.md#commit-messages)

Previously breadcrumb was structured in a way that was hard to test the responsiveness and resizing of the directive. This refactoring changes the directive & tests accordingly.
