### PR TITLE
chore(build): replace NPM with Yarn in check-pr.sh scripts

### DIFF
--- a/build/scripts/check-pr.sh
+++ b/build/scripts/check-pr.sh
@@ -60,7 +60,7 @@ rm -rf dist
 
 # get all modules
 echo ".. installing node modules"
-npm install
+yarn install
 
 # compile typescript (to run the gulp clean command)
 echo ".. compile TypeScript"


### PR DESCRIPTION
This doesn't address any issues, just replaces one build script used when testing PRs.