### PR TITLE
refactor(): common TypeScript style

### DIFF
--- a/build/config/build.ts
+++ b/build/config/build.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as yargs from 'yargs';
 
 export class BuildConfig {

--- a/build/config/karma.ts
+++ b/build/config/karma.ts
@@ -1,6 +1,4 @@
-'use strict';
-
-import {BuildConfig} from './build';
+import { BuildConfig } from './build';
 import * as karma from 'karma';
 import * as webpack from 'webpack';
 import * as webpackConfig from './webpack';

--- a/build/config/webpack.ts
+++ b/build/config/webpack.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as webpack from 'webpack';
 
 /**

--- a/build/gulp/BaseGulpTask.ts
+++ b/build/gulp/BaseGulpTask.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /** @class */
 export class BaseGulpTask {
 

--- a/build/gulp/tasks/build-lib.ts
+++ b/build/gulp/tasks/build-lib.ts
@@ -1,8 +1,6 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
-import {BuildConfig} from '../../config/build';
-import {Utils} from '../utils';
+import { BaseGulpTask } from '../BaseGulpTask';
+import { BuildConfig } from '../../config/build';
+import { Utils } from '../utils';
 import * as gulp from 'gulp';
 import * as yargs from 'yargs';
 import * as webpack from 'webpack';

--- a/build/gulp/tasks/clean-build.ts
+++ b/build/gulp/tasks/clean-build.ts
@@ -1,9 +1,7 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
+import { BaseGulpTask } from '../BaseGulpTask';
 import * as gulp from 'gulp';
-import {BuildConfig} from '../../config/build';
-import {Utils} from '../utils';
+import { BuildConfig } from '../../config/build';
+import { Utils } from '../utils';
 import * as yargs from 'yargs';
 let $: any = require('gulp-load-plugins')({ lazy: true });
 

--- a/build/gulp/tasks/clean-lib.ts
+++ b/build/gulp/tasks/clean-lib.ts
@@ -1,9 +1,7 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
+import { BaseGulpTask } from '../BaseGulpTask';
 import * as gulp from 'gulp';
-import {BuildConfig} from '../../config/build';
-import {Utils} from '../utils';
+import { BuildConfig } from '../../config/build';
+import { Utils } from '../utils';
 import * as yargs from 'yargs';
 let $: any = require('gulp-load-plugins')({ lazy: true });
 

--- a/build/gulp/tasks/clean.ts
+++ b/build/gulp/tasks/clean.ts
@@ -1,6 +1,4 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
+import { BaseGulpTask } from '../BaseGulpTask';
 import * as gulp from 'gulp';
 import * as runSequence from 'run-sequence';
 

--- a/build/gulp/tasks/live-dev.ts
+++ b/build/gulp/tasks/live-dev.ts
@@ -1,7 +1,5 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
-import {Utils} from '../utils';
+import { BaseGulpTask } from '../BaseGulpTask';
+import { Utils } from '../utils';
 import * as gulp from 'gulp';
 import * as path from 'path';
 import * as yargs from 'yargs';

--- a/build/gulp/tasks/test.ts
+++ b/build/gulp/tasks/test.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { BaseGulpTask } from '../BaseGulpTask';
 import { Utils } from '../utils';
 import { BuildConfig } from '../../config/build';

--- a/build/gulp/tasks/transpile-ts.ts
+++ b/build/gulp/tasks/transpile-ts.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import {BaseGulpTask} from '../BaseGulpTask';
 import * as gulp from 'gulp';
 import {Utils} from '../utils';

--- a/build/gulp/tasks/validate-build.ts
+++ b/build/gulp/tasks/validate-build.ts
@@ -1,7 +1,5 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
-import {Utils} from '../utils';
+import { BaseGulpTask } from '../BaseGulpTask';
+import { Utils } from '../utils';
 import * as gulp from 'gulp';
 import * as runSequence from 'run-sequence';
 
@@ -16,7 +14,7 @@ export class GulpTask extends BaseGulpTask {
    * @property  {string}  description   - Help description for the task.
    */
   public static description: string = 'Validates the build runs \'vet\', \'transpile-ts\', \'build-lib\' and \'test\' in a sequence'
-                                      + GulpTask.helpMargin;
+  + GulpTask.helpMargin;
 
   /**
    * @property  {string[]}  dependencies  - Array of all tasks that should be run before this one.

--- a/build/gulp/tasks/vet-build-ts.ts
+++ b/build/gulp/tasks/vet-build-ts.ts
@@ -1,9 +1,7 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
+import { BaseGulpTask } from '../BaseGulpTask';
 import * as gulp from 'gulp';
-import {BuildConfig} from '../../config/build';
-import {Utils} from '../utils';
+import { BuildConfig } from '../../config/build';
+import { Utils } from '../utils';
 import * as yargs from 'yargs';
 let $: any = require('gulp-load-plugins')({ lazy: true });
 

--- a/build/gulp/tasks/vet-lib-ts.ts
+++ b/build/gulp/tasks/vet-lib-ts.ts
@@ -1,9 +1,7 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
+import { BaseGulpTask } from '../BaseGulpTask';
 import * as gulp from 'gulp';
-import {BuildConfig} from '../../config/build';
-import {Utils} from '../utils';
+import { BuildConfig } from '../../config/build';
+import { Utils } from '../utils';
 import * as yargs from 'yargs';
 let $: any = require('gulp-load-plugins')({ lazy: true });
 

--- a/build/gulp/tasks/vet.ts
+++ b/build/gulp/tasks/vet.ts
@@ -1,7 +1,5 @@
-'use strict';
-
-import {BaseGulpTask} from '../BaseGulpTask';
-import {Utils} from '../utils';
+import { BaseGulpTask } from '../BaseGulpTask';
+import { Utils } from '../utils';
 
 /**
  * Vets all built files as the gulp task 'vet'.

--- a/build/gulp/utils.ts
+++ b/build/gulp/utils.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as events from 'events';
 import * as childProcess from 'child_process';
 let $: any = require('gulp-load-plugins')({ lazy: true });

--- a/build/scripts/ScriptUtils.ts
+++ b/build/scripts/ScriptUtils.ts
@@ -1,13 +1,11 @@
-'use strict';
-
-  /**
-   * Library version dependencies this library has.
-   *
-   * @typedef libraryDependencies
-   * @type {Object}
-   * @prop {string?}   angular        - Version of Angular required.
-   * @prop {string?}   officeUiFabric - Version of the Office UI Fabric required.
-   */
+/**
+ * Library version dependencies this library has.
+ *
+ * @typedef libraryDependencies
+ * @type {Object}
+ * @prop {string?}   angular        - Version of Angular required.
+ * @prop {string?}   officeUiFabric - Version of the Office UI Fabric required.
+ */
 export interface ILibraryDependencies {
   angularLib?: string;
   officeUiFabricLib?: string;

--- a/build/scripts/update-nuget-versions.ts
+++ b/build/scripts/update-nuget-versions.ts
@@ -7,9 +7,7 @@
 // --src = location of the cloned source repo (ng-officeuifabric)
 // --pkg = location of the cloned package repo (nuget-ngofficeuifabric)
 
-'use strict';
-
-import {ScriptUtils, ILibraryDependencies} from './ScriptUtils';
+import { ScriptUtils, ILibraryDependencies } from './ScriptUtils';
 import * as fs from 'fs';
 import * as yargs from 'yargs';
 import * as xmldom from 'xmldom';

--- a/build/scripts/update-package-versions.ts
+++ b/build/scripts/update-package-versions.ts
@@ -7,9 +7,7 @@
 // --src = location of the cloned source repo (ng-officeuifabric)
 // --pkg = location of the cloned package repo (ngofficeuifabric)
 
-'use strict';
-
-import {ScriptUtils, ILibraryDependencies} from './ScriptUtils';
+import { ScriptUtils, ILibraryDependencies } from './ScriptUtils';
 import * as fs from 'fs';
 import * as yargs from 'yargs';
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import * as fs from 'fs';
-import {BuildConfig} from './build/config/build';
+import { BuildConfig } from './build/config/build';
 let gulp: any = require('gulp-help')(require('gulp'));
 
 /**

--- a/src/components/breadcrumb/breadcrumbDirective.spec.ts
+++ b/src/components/breadcrumb/breadcrumbDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('breadcrumb: <uif-breadcrumb />', () => {

--- a/src/components/breadcrumb/breadcrumbDirective.ts
+++ b/src/components/breadcrumb/breadcrumbDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 /**

--- a/src/components/button/buttonDirective.spec.ts
+++ b/src/components/button/buttonDirective.spec.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import * as angular from 'angular';
-import {ButtonTypeEnum} from './buttonTypeEnum';
+import { ButtonTypeEnum } from './buttonTypeEnum';
 
 describe('buttonDirective: <uif-button />', () => {
 

--- a/src/components/button/buttonDirective.ts
+++ b/src/components/button/buttonDirective.ts
@@ -1,8 +1,6 @@
-'use strict';
-
 import * as angular from 'angular';
-import {ButtonTypeEnum} from './buttonTypeEnum';
-import {ButtonTemplateType} from './buttonTemplateType';
+import { ButtonTypeEnum } from './buttonTypeEnum';
+import { ButtonTemplateType } from './buttonTemplateType';
 
 export interface IButtonScope extends angular.IScope {
   disabled: boolean;
@@ -136,9 +134,10 @@ export class ButtonDirective implements angular.IDirective {
     }
   }
 
-  public compile(element: angular.IAugmentedJQuery,
-                 attrs: IButtonAttributes,
-                 transclude: angular.ITranscludeFunction): angular.IDirectivePrePost {
+  public compile(
+    element: angular.IAugmentedJQuery,
+    attrs: IButtonAttributes,
+    transclude: angular.ITranscludeFunction): angular.IDirectivePrePost {
     return {
       post: this.postLink,
       pre: this.preLink
@@ -148,11 +147,12 @@ export class ButtonDirective implements angular.IDirective {
   /**
    * Update the scope before linking everything up.
    */
-  private preLink(scope: IButtonScope,
-                  element: angular.IAugmentedJQuery,
-                  attrs: IButtonAttributes,
-                  controllers: any,
-                  transclude: angular.ITranscludeFunction): void {
+  private preLink(
+    scope: IButtonScope,
+    element: angular.IAugmentedJQuery,
+    attrs: IButtonAttributes,
+    controllers: any,
+    transclude: angular.ITranscludeFunction): void {
 
     attrs.$observe('disabled', (isDisabled) => {
       scope.disabled = !!isDisabled;
@@ -169,17 +169,18 @@ export class ButtonDirective implements angular.IDirective {
   /**
    * Check the rendered HTML for anything that is invalid.
    */
-  private postLink(scope: IButtonScope,
-                   element: angular.IAugmentedJQuery,
-                   attrs: IButtonAttributes,
-                   controllers: any,
-                   transclude: angular.ITranscludeFunction): void {
+  private postLink(
+    scope: IButtonScope,
+    element: angular.IAugmentedJQuery,
+    attrs: IButtonAttributes,
+    controllers: any,
+    transclude: angular.ITranscludeFunction): void {
 
     // if an icon was added to the button's contents for specific button types
     //  that don't support icons, remove the icon
     if (angular.isUndefined(attrs.uifType) ||
-        attrs.uifType === ButtonTypeEnum[ButtonTypeEnum.primary] ||
-        attrs.uifType === ButtonTypeEnum[ButtonTypeEnum.compound]) {
+      attrs.uifType === ButtonTypeEnum[ButtonTypeEnum.primary] ||
+      attrs.uifType === ButtonTypeEnum[ButtonTypeEnum.compound]) {
       let iconElement: JQuery = element.find('uif-icon');
       if (iconElement.length !== 0) {
         iconElement.remove();
@@ -222,11 +223,11 @@ export class ButtonDirective implements angular.IDirective {
 
             // wrap the button label
             if (clone[i].classList[0] === 'ng-scope' &&
-                clone[i].classList.length === 1) {
+              clone[i].classList.length === 1) {
               wrapper = angular.element('<span></span>');
               wrapper.addClass('ms-Button-label').append(clone[i]);
               element.append(wrapper);
-            // add the description... just add it to the button
+              // add the description... just add it to the button
             } else {
               element.append(clone[i]);
             }

--- a/src/components/button/buttonTemplateType.ts
+++ b/src/components/button/buttonTemplateType.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for all possible button template types not public, only use within directive.
  *

--- a/src/components/button/buttonTypeEnum.ts
+++ b/src/components/button/buttonTypeEnum.ts
@@ -1,16 +1,14 @@
-'use strict';
-
 /**
  * Enum for all possible button types supported by Office UI Fabric. Enums in JavaScript are always indexed but this enum is
  * intended to be used as a striangular.
- * 
+ *
  * @readonly
  * @enum {string}
  * @usage
- * 
- * This is used to generate the string that you pass into the <uif-button /> directive. Specifically, the string is passed 
+ *
+ * This is used to generate the string that you pass into the <uif-button /> directive. Specifically, the string is passed
  * to the `uif-type` attribute. To evaluate the enum value as a string:
- * 
+ *
  * let buttonType: string = ButtonTypeEnum[ButtonTypeEnum.primary];
  */
 export enum ButtonTypeEnum {

--- a/src/components/callout/calloutArrowEnum.ts
+++ b/src/components/callout/calloutArrowEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for callout arrow direction. It is intended to use as string as `uif-arrow` attribute value on `uif-callout` directive.
  *

--- a/src/components/callout/calloutDirective.spec.ts
+++ b/src/components/callout/calloutDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('calloutDirectives:', () => {

--- a/src/components/callout/calloutDirective.ts
+++ b/src/components/callout/calloutDirective.ts
@@ -1,8 +1,6 @@
-'use strict';
-
 import * as angular from 'angular';
-import {CalloutType} from './calloutTypeEnum';
-import {CalloutArrow} from './calloutArrowEnum';
+import { CalloutType } from './calloutTypeEnum';
+import { CalloutArrow } from './calloutArrowEnum';
 
 
 /**

--- a/src/components/callout/calloutTypeEnum.ts
+++ b/src/components/callout/calloutTypeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  *
  * Enum for callout type. It is intended to use as string as `uif-type` attribute value on `uif-callout` directive.

--- a/src/components/choicefield/choicefieldDirective.ts
+++ b/src/components/choicefield/choicefieldDirective.ts
@@ -1,6 +1,5 @@
-﻿'use strict';
-
 import * as angular from 'angular';
+
 import { ChoicefieldType } from './choicefieldTypeEnum';
 
 /**
@@ -100,8 +99,7 @@ export class ChoicefieldOptionDirective implements angular.IDirective {
   public compile(
     templateElement: angular.IAugmentedJQuery,
     templateAttributes: angular.IAttributes,
-    transclude: angular.ITranscludeFunction
-  ): angular.IDirectivePrePost {
+    transclude: angular.ITranscludeFunction): angular.IDirectivePrePost {
     let input: angular.IAugmentedJQuery = templateElement.find('input');
     if (!('ngModel' in templateAttributes)) {
       // remove ng-model, as this is an optional attribute.
@@ -299,8 +297,7 @@ export class ChoicefieldGroupDirective implements angular.IDirective {
   public compile(
     templateElement: angular.IAugmentedJQuery,
     templateAttributes: angular.IAttributes,
-    transclude: angular.ITranscludeFunction
-  ): angular.IDirectivePrePost {
+    transclude: angular.ITranscludeFunction): angular.IDirectivePrePost {
     return {
       pre: this.preLink
     };

--- a/src/components/choicefield/choicefieldTypeEnum.ts
+++ b/src/components/choicefield/choicefieldTypeEnum.ts
@@ -1,12 +1,10 @@
-'use strict';
-
 /**
  * @ngdoc enum
  * @name choicefieldType
  * @module officeuifabric.components.choicefield
- * 
+ *
  * @readonly
- * 
+ *
  * @description
  * This attribute can be set on the uif-choicefield-option directive and determines whether it
  * is a radio button or a checkbox

--- a/src/components/commandbar/commandBarDirective.ts
+++ b/src/components/commandbar/commandBarDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 /**

--- a/src/components/contextualmenu/contextualMenu.spec.ts
+++ b/src/components/contextualmenu/contextualMenu.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('contextualmenu: <uif-contextual-menu />', () => {

--- a/src/components/contextualmenu/contextualMenu.ts
+++ b/src/components/contextualmenu/contextualMenu.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 /**

--- a/src/components/datepicker/datepickerDirective.ts
+++ b/src/components/datepicker/datepickerDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 /**

--- a/src/components/dialog/dialogDirective.spec.ts
+++ b/src/components/dialog/dialogDirective.spec.ts
@@ -1,6 +1,5 @@
-'use strict';
-
 import * as angular from 'angular';
+
 describe('uifDialog: <uif-dialog />', () => {
   let element: JQuery;
   let scope: any;

--- a/src/components/dialog/dialogDirective.ts
+++ b/src/components/dialog/dialogDirective.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import * as angular from 'angular';
-import {DialogTypeEnum, DialogActionsPositionEnum} from './dialogEnums';
+import { DialogTypeEnum, DialogActionsPositionEnum } from './dialogEnums';
 
 /**
  * @ngdoc interface
@@ -250,21 +248,22 @@ export class DialogActionsDirective implements angular.IDirective {
     const directive: angular.IDirectiveFactory = () => new DialogActionsDirective();
     return directive;
   }
-  public link(scope: IDialogActionsPositionScope,
-              element: angular.IAugmentedJQuery,
-              attrs: angular.IAttributes,
-              controller: DialogActionsController): void {
-              scope.$watch('uifPosition', (newValue: string, oldValue: string) => {
-                if (typeof (newValue) !== 'undefined') {
-                  if (DialogActionsPositionEnum[newValue] === undefined) {
-                    controller.$log.error('Error [ngOfficeUiFabric] officeuifabric.components.dialog - Unsupported type:' +
-                      'The type (\'' + scope.uifPosition + '\') is not supported by the Office UI Fabric.' +
-                      'Supported options are listed here: ' +
-                      'https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/src/components/dialog/dialogEnums.ts'
-                    );
+  public link(
+    scope: IDialogActionsPositionScope,
+    element: angular.IAugmentedJQuery,
+    attrs: angular.IAttributes,
+    controller: DialogActionsController): void {
+    scope.$watch('uifPosition', (newValue: string, oldValue: string) => {
+      if (typeof (newValue) !== 'undefined') {
+        if (DialogActionsPositionEnum[newValue] === undefined) {
+          controller.$log.error('Error [ngOfficeUiFabric] officeuifabric.components.dialog - Unsupported type:' +
+            'The type (\'' + scope.uifPosition + '\') is not supported by the Office UI Fabric.' +
+            'Supported options are listed here: ' +
+            'https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/src/components/dialog/dialogEnums.ts'
+          );
 
-                  }
-                }
+        }
+      }
     });
   }
 }

--- a/src/components/dialog/dialogEnums.ts
+++ b/src/components/dialog/dialogEnums.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enumeration of the different dialog types supported by the dialog directive.
  *

--- a/src/components/dropdown/dropdownDirective.ts
+++ b/src/components/dropdown/dropdownDirective.ts
@@ -1,6 +1,4 @@
-﻿'use strict';
-
-import * as angular from 'angular';
+﻿import * as angular from 'angular';
 
 /**
  * @ngdoc interface

--- a/src/components/facepile/facepileDirective.ts
+++ b/src/components/facepile/facepileDirective.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import * as angular from 'angular';
-import {IPerson} from '../../core/person';
+import { IPerson } from '../../core/person';
 
 /**
  * @ngdoc interface
@@ -176,9 +174,10 @@ export class FacepileAddIconDirective implements angular.IDirective {
   }
 
   public link(scope: IFacepileAddIconScope, elem: angular.IAugmentedJQuery, attrs: angular.IAttributes): void {
-  {
-    scope.parentScope = <IFacepileScope>scope.$parent.$parent;
-  }};
+    {
+      scope.parentScope = <IFacepileScope>scope.$parent.$parent;
+    }
+  };
 
 }
 
@@ -194,5 +193,5 @@ export class FacepileAddIconDirective implements angular.IDirective {
 export let module: angular.IModule = angular.module('officeuifabric.components.facepile', [
   'officeuifabric.components'
 ])
-.directive('uifFacepile', FacepileDirective.factory())
-.directive('uifFacepileAddIcon', FacepileAddIconDirective.factory());
+  .directive('uifFacepile', FacepileDirective.factory())
+  .directive('uifFacepileAddIcon', FacepileAddIconDirective.factory());

--- a/src/components/icon/demoTypeScriptUsage/index.ts
+++ b/src/components/icon/demoTypeScriptUsage/index.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import * as angular from 'angular';
-import {IconEnum} from './../iconEnum';
+import { IconEnum } from './../iconEnum';
 
 export class DemoController {
   public icons: string[] = [];
@@ -17,7 +15,7 @@ export class DemoController {
   /**
    * @description
    * Populates the icon collection using the provided enum.
-   * 
+   *
    * @returns {string[]}  - Array of icons as strings.
    */
   private _fillIconCollection(): string[] {
@@ -39,6 +37,6 @@ export class DemoController {
 }
 
 export var module: angular.IModule = angular.module('demoApp', [
-    'officeuifabric.core',
-    'officeuifabric.components.icon'])
+  'officeuifabric.core',
+  'officeuifabric.components.icon'])
   .controller('demoController', [DemoController]);

--- a/src/components/icon/iconDirective.spec.ts
+++ b/src/components/icon/iconDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 import { IconEnum } from './iconEnum';
 

--- a/src/components/icon/iconDirective.ts
+++ b/src/components/icon/iconDirective.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import * as angular from 'angular';
-import {IconEnum} from './iconEnum';
+import { IconEnum } from './iconEnum';
 
 /**
  * @ngdoc interface

--- a/src/components/icon/iconEnum.ts
+++ b/src/components/icon/iconEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for all icons supported by Office UI Fabric. Enums in JavaScript are always number indexed, but this enum is
  * intended to be used as a striangular.

--- a/src/components/label/labelDirective.spec.ts
+++ b/src/components/label/labelDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('<uif-label></uif-label>', () => {
@@ -93,7 +91,7 @@ describe('<uif-label></uif-label>', () => {
 
         expect(label).not.toHaveClass('is-required');
         expect(label).not.toHaveClass('is-disabled');
-    }));
+      }));
 
 
   });

--- a/src/components/label/labelDirective.ts
+++ b/src/components/label/labelDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 /**

--- a/src/components/link/linkDirective.spec.ts
+++ b/src/components/link/linkDirective.spec.ts
@@ -1,60 +1,58 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('linkDirective: <uif-link />', () => {
-    let element: JQuery;
-    let scope: angular.IScope;
+  let element: JQuery;
+  let scope: angular.IScope;
 
-    beforeEach(() => {
-        angular.mock.module('officeuifabric.core');
-        angular.mock.module('officeuifabric.components.link');
-    });
+  beforeEach(() => {
+    angular.mock.module('officeuifabric.core');
+    angular.mock.module('officeuifabric.components.link');
+  });
 
-    beforeEach(inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        element = angular.element('<uif-link ng-href="http://ngofficeuifabric.com">Link Text</uif-link>');
-        scope = $rootScope;
-        $compile(element)(scope);
-        scope.$digest();
-        element = jQuery(element[0]);
-    }));
-
-
-    it('should render as an <a>', () => {
-
-        let aElement: JQuery = element;
-
-        expect(aElement).toEqual('a');
-
-    });
+  beforeEach(inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    element = angular.element('<uif-link ng-href="http://ngofficeuifabric.com">Link Text</uif-link>');
+    scope = $rootScope;
+    $compile(element)(scope);
+    scope.$digest();
+    element = jQuery(element[0]);
+  }));
 
 
-    it('should have an href attribute', () => {
+  it('should render as an <a>', () => {
 
-        let aElement: JQuery = element;
+    let aElement: JQuery = element;
 
-        expect(aElement).toHaveAttr('href');
+    expect(aElement).toEqual('a');
 
-    });
-
-
-    it('should render correct Office UI Fabric CSS classes', () => {
-
-        let aElement: JQuery = element;
-
-        // ensure link has the correct classes
-        expect(aElement.eq(0)).toHaveClass('ms-Link');
-
-    });
+  });
 
 
-    it('should render the correct text', () => {
+  it('should have an href attribute', () => {
 
-        let aElement: JQuery = element;
+    let aElement: JQuery = element;
 
-        // make sure it has the correct text
-        expect(aElement.eq(0)).toHaveText('Link Text');
+    expect(aElement).toHaveAttr('href');
 
-    });
+  });
+
+
+  it('should render correct Office UI Fabric CSS classes', () => {
+
+    let aElement: JQuery = element;
+
+    // ensure link has the correct classes
+    expect(aElement.eq(0)).toHaveClass('ms-Link');
+
+  });
+
+
+  it('should render the correct text', () => {
+
+    let aElement: JQuery = element;
+
+    // make sure it has the correct text
+    expect(aElement.eq(0)).toHaveText('Link Text');
+
+  });
 
 });

--- a/src/components/link/linkDirective.ts
+++ b/src/components/link/linkDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 /**
@@ -47,6 +45,6 @@ export class LinkDirective implements angular.IDirective {
  *
  */
 export let module: angular.IModule = angular.module('officeuifabric.components.link', [
-    'officeuifabric.components'
-  ])
+  'officeuifabric.components'
+])
   .directive('uifLink', LinkDirective.factory());

--- a/src/components/list/listDirective.spec.ts
+++ b/src/components/list/listDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 import { ListItemSelectModeEnum } from './listItemSelectModeEnum';
 import { ListItemTypeEnum } from './listItemTypeEnum';

--- a/src/components/list/listDirective.ts
+++ b/src/components/list/listDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 import { ListItemSelectModeEnum } from './listItemSelectModeEnum';
 import { ListItemTypeEnum } from './listItemTypeEnum';

--- a/src/components/list/listItemSelectModeEnum.ts
+++ b/src/components/list/listItemSelectModeEnum.ts
@@ -1,12 +1,10 @@
-'use strict';
-
 /**
  * Enumeration of the different list item selection modes supported by the list directive.
- * 
+ *
  * @readonly
  * @enum {string}
  * @usage
- * 
+ *
  * This enumeration is used to specify which list item selection mode the list should use.
  */
 export enum ListItemSelectModeEnum {

--- a/src/components/list/listItemTypeEnum.ts
+++ b/src/components/list/listItemTypeEnum.ts
@@ -1,12 +1,10 @@
-'use strict';
-
 /**
  * Enumeration of the different list item types that determine how the item is rendered.
- * 
+ *
  * @readonly
  * @enum {string}
  * @usage
- * 
+ *
  * This enumeration is used to specify how a list item should be rendered.
  */
 export enum ListItemTypeEnum {

--- a/src/components/list/listLayoutEnum.ts
+++ b/src/components/list/listLayoutEnum.ts
@@ -1,12 +1,10 @@
-'use strict';
-
 /**
  * Enumeration of the different ways in which the list can be rendered.
- * 
+ *
  * @readonly
  * @enum {string}
  * @usage
- * 
+ *
  * This enumeration is used to specify how a list should be rendered.
  */
 export enum ListLayoutEnum {

--- a/src/components/messagebanner/messageBannerDirective.spec.ts
+++ b/src/components/messagebanner/messageBannerDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('messageBannerDirective: <uif-message-banner />', () => {

--- a/src/components/messagebanner/messageBannerDirective.ts
+++ b/src/components/messagebanner/messageBannerDirective.ts
@@ -1,7 +1,4 @@
-'use strict';
-
 import * as angular from 'angular';
-
 
 /**
  * @controller

--- a/src/components/messagebar/messageBarDirective.spec.ts
+++ b/src/components/messagebar/messageBarDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('messageBarDirective: <uif-message-bar />', () => {

--- a/src/components/messagebar/messageBarDirective.ts
+++ b/src/components/messagebar/messageBarDirective.ts
@@ -1,9 +1,5 @@
-
-'use strict';
-
 import * as angular from 'angular';
 import { MessageBarTypeEnum } from './messageBarTypeEnum';
-
 
 /**
  * @controller

--- a/src/components/messagebar/messageBarTypeEnum.ts
+++ b/src/components/messagebar/messageBarTypeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for supported types of the uif-messagebar directive
  * This enum is intended to be used as a striangular.

--- a/src/components/navbar/navbarDirective.spec.ts
+++ b/src/components/navbar/navbarDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('navbar: <uif-nav-bar />', () => {

--- a/src/components/navbar/navbarDirective.ts
+++ b/src/components/navbar/navbarDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 import { ContextualMenuDirective, ContextualMenuController } from './../contextualmenu/contextualMenu';
 

--- a/src/components/orgchart/orgChartDirective.spec.ts
+++ b/src/components/orgchart/orgChartDirective.spec.ts
@@ -1,8 +1,6 @@
-'use strict';
-
 import * as angular from 'angular';
-import {OrgChartPresenceEnum} from './orgChartPresenceEnum';
-import {OrgChartSelectModeEnum} from './orgChartSelectModeEnum';
+import { OrgChartPresenceEnum } from './orgChartPresenceEnum';
+import { OrgChartSelectModeEnum } from './orgChartSelectModeEnum';
 
 describe('orgChartDirective: <uif-org-chart />', () => {
 
@@ -40,36 +38,36 @@ describe('orgChartDirective: <uif-org-chart />', () => {
       // sample data
       sample = [
         {
-            country: 'Denmark',
-            imageUrl: 'Persona.Person2.png',
-            name: 'Kevin Magnussen',
-            presence: 'available',
-            selected: false,
-            team: 'Renault'
+          country: 'Denmark',
+          imageUrl: 'Persona.Person2.png',
+          name: 'Kevin Magnussen',
+          presence: 'available',
+          selected: false,
+          team: 'Renault'
         },
         {
-            country: '	Germany',
-            imageUrl: 'Persona.Person2.png',
-            name: 'Sebastian Vettel',
-            presence: 'busy',
-            selected: false,
-            team: 'Ferrari'
+          country: '	Germany',
+          imageUrl: 'Persona.Person2.png',
+          name: 'Sebastian Vettel',
+          presence: 'busy',
+          selected: false,
+          team: 'Ferrari'
         },
         {
-            country: '	United Kingdom',
-            imageUrl: 'Persona.Person2.png',
-            name: 'Jolyon Palmer',
-            presence: 'away',
-            selected: false,
-            team: 'Renault'
+          country: '	United Kingdom',
+          imageUrl: 'Persona.Person2.png',
+          name: 'Jolyon Palmer',
+          presence: 'away',
+          selected: false,
+          team: 'Renault'
         },
         {
-            country: 'United Kingdom',
-            imageUrl: 'Persona.Person2.png',
-            name: 'Lewis Hamilton',
-            presence: 'blocked',
-            selected: false,
-            team: '	Mercedes'
+          country: 'United Kingdom',
+          imageUrl: 'Persona.Person2.png',
+          name: 'Lewis Hamilton',
+          presence: 'blocked',
+          selected: false,
+          team: '	Mercedes'
         }
       ];
 
@@ -137,11 +135,11 @@ describe('orgChartDirective: <uif-org-chart />', () => {
 
     it('should log error on invalid select-mode', () => {
 
-        element = angular.element(`<uif-org-chart uif-select-mode="INVALID"></uif-org-chart`);
-        compile(element)(scope);
-        scope.$digest();
+      element = angular.element(`<uif-org-chart uif-select-mode="INVALID"></uif-org-chart`);
+      compile(element)(scope);
+      scope.$digest();
 
-        expect(log.error.logs.length).toEqual(1);
+      expect(log.error.logs.length).toEqual(1);
 
     });
 
@@ -236,36 +234,36 @@ describe('orgChartDirective: <uif-org-chart />', () => {
       // sample data
       sample = [
         {
-            country: 'Denmark',
-            imageUrl: 'Persona.Person2.png',
-            name: 'Kevin Magnussen',
-            presence: 'available',
-            selected: false,
-            team: 'Renault'
+          country: 'Denmark',
+          imageUrl: 'Persona.Person2.png',
+          name: 'Kevin Magnussen',
+          presence: 'available',
+          selected: false,
+          team: 'Renault'
         },
         {
-            country: '	Germany',
-            imageUrl: 'Persona.Person2.png',
-            name: 'Sebastian Vettel',
-            presence: 'busy',
-            selected: false,
-            team: 'Ferrari'
+          country: '	Germany',
+          imageUrl: 'Persona.Person2.png',
+          name: 'Sebastian Vettel',
+          presence: 'busy',
+          selected: false,
+          team: 'Ferrari'
         },
         {
-            country: '	United Kingdom',
-            imageUrl: 'Persona.Person2.png',
-            name: 'Jolyon Palmer',
-            presence: 'away',
-            selected: false,
-            team: 'Renault'
+          country: '	United Kingdom',
+          imageUrl: 'Persona.Person2.png',
+          name: 'Jolyon Palmer',
+          presence: 'away',
+          selected: false,
+          team: 'Renault'
         },
         {
-            country: 'United Kingdom',
-            imageUrl: 'Persona.Person2.png',
-            name: 'Lewis Hamilton',
-            presence: 'blocked',
-            selected: false,
-            team: '	Mercedes'
+          country: 'United Kingdom',
+          imageUrl: 'Persona.Person2.png',
+          name: 'Lewis Hamilton',
+          presence: 'blocked',
+          selected: false,
+          team: '	Mercedes'
         }
       ];
 
@@ -645,7 +643,7 @@ describe('orgChartDirective: <uif-org-chart />', () => {
 
       expect(presenceElement.prop('tagName')).toEqual('DIV');
       expect(presenceElement).toHaveClass('ms-Persona-presence');
-      expect(presenceElement).toHaveCss({display: 'none'});
+      expect(presenceElement).toHaveCss({ display: 'none' });
 
     });
 

--- a/src/components/orgchart/orgChartDirective.ts
+++ b/src/components/orgchart/orgChartDirective.ts
@@ -1,9 +1,7 @@
-'use strict';
-
 import * as angular from 'angular';
-import {OrgChartPresenceEnum} from './orgChartPresenceEnum';
-import {OrgChartStyleEnum} from './orgChartStyleEnum';
-import {OrgChartSelectModeEnum} from './orgChartSelectModeEnum';
+import { OrgChartPresenceEnum } from './orgChartPresenceEnum';
+import { OrgChartStyleEnum } from './orgChartStyleEnum';
+import { OrgChartSelectModeEnum } from './orgChartSelectModeEnum';
 
 export interface IOrgChartScope extends angular.IScope {
   selectMode?: OrgChartSelectModeEnum;
@@ -302,7 +300,7 @@ export class OrgChartPersonaDirective implements angular.IDirective {
 
     // handle selection
     if (scope.selected === undefined) {
-        scope.selected = false;
+      scope.selected = false;
     }
 
     // handle status-attribute
@@ -641,7 +639,7 @@ export class OrgChartGroupByFilter {
 
   public static factory(): any {
 
-    return function(collection: any[], key: string): any[] {
+    return function (collection: any[], key: string): any[] {
       let result: any[] = [];
       if (!collection) {
         return;

--- a/src/components/orgchart/orgChartPresenceEnum.ts
+++ b/src/components/orgchart/orgChartPresenceEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc enum
  * @name OrgChartPresenceEnum

--- a/src/components/orgchart/orgChartSelectModeEnum.ts
+++ b/src/components/orgchart/orgChartSelectModeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc filter
  * @name OrgChartSelectModeEnum

--- a/src/components/orgchart/orgChartStyleEnum.ts
+++ b/src/components/orgchart/orgChartStyleEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc enum
  * @name OrgChartStyleModeEnum

--- a/src/components/overlay/overlayDirective.spec.ts
+++ b/src/components/overlay/overlayDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('overlayDirective: <uif-overlay />', () => {

--- a/src/components/overlay/overlayDirective.ts
+++ b/src/components/overlay/overlayDirective.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import * as angular from 'angular';
-import {OverlayMode} from './overlayModeEnum';
+import { OverlayMode } from './overlayModeEnum';
 
 /**
  * @ngdoc interface
@@ -14,7 +12,7 @@ import {OverlayMode} from './overlayModeEnum';
  * @property {string} uifType - Icon to display. Possible types are defined in {@link IconEnum}.
  */
 export interface IOverlayScope extends angular.IScope {
-    uifMode: OverlayMode;
+  uifMode: OverlayMode;
 }
 
 /**
@@ -25,9 +23,9 @@ export interface IOverlayScope extends angular.IScope {
  * Used to more easily inject the Angular $log service into the directive.
  */
 class OverlayController {
-    public static $inject: string[] = ['$log'];
-    constructor(public log: angular.ILogService) {
-    }
+  public static $inject: string[] = ['$log'];
+  constructor(public log: angular.ILogService) {
+  }
 }
 
 /**
@@ -49,38 +47,38 @@ class OverlayController {
  */
 export class OverlayDirective implements angular.IDirective {
 
-    public static log: angular.ILogService;
+  public static log: angular.ILogService;
 
-    public restrict: string = 'E';
-    public template: string = '<div class="ms-Overlay" ng-class="{\'ms-Overlay--dark\': uifMode == \'dark\'}" ng-transclude></div>';
-    public scope: {} = {
-        uifMode: '@'
-    };
-    public transclude: boolean = true;
+  public restrict: string = 'E';
+  public template: string = '<div class="ms-Overlay" ng-class="{\'ms-Overlay--dark\': uifMode == \'dark\'}" ng-transclude></div>';
+  public scope: {} = {
+    uifMode: '@'
+  };
+  public transclude: boolean = true;
 
-    public static factory(): angular.IDirectiveFactory {
-        const directive: angular.IDirectiveFactory = (log: angular.ILogService) => new OverlayDirective(log);
-        directive.$inject = ['$log'];
-        return directive;
-    }
+  public static factory(): angular.IDirectiveFactory {
+    const directive: angular.IDirectiveFactory = (log: angular.ILogService) => new OverlayDirective(log);
+    directive.$inject = ['$log'];
+    return directive;
+  }
 
-    public constructor(public log: angular.ILogService) {
-        OverlayDirective.log = log;
-    }
+  public constructor(public log: angular.ILogService) {
+    OverlayDirective.log = log;
+  }
 
-    public link(scope: IOverlayScope): void {
+  public link(scope: IOverlayScope): void {
 
-        scope.$watch('uifMode', (newValue: string, oldValue: string) => {
+    scope.$watch('uifMode', (newValue: string, oldValue: string) => {
 
-            // verify a valid overlay mode was passed in
-            if (OverlayMode[newValue] === undefined) {
-                OverlayDirective.log.error('Error [ngOfficeUiFabric] officeuifabric.components.overlay - Unsupported overlay mode: ' +
-                    'The overlay mode (\'' + scope.uifMode + '\') is not supported by the Office UI Fabric. ' +
-                    'Supported options are listed here: ' +
-                    'https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/src/components/overlay/overlayModeEnum.ts');
-            }
-        });
-    };
+      // verify a valid overlay mode was passed in
+      if (OverlayMode[newValue] === undefined) {
+        OverlayDirective.log.error('Error [ngOfficeUiFabric] officeuifabric.components.overlay - Unsupported overlay mode: ' +
+          'The overlay mode (\'' + scope.uifMode + '\') is not supported by the Office UI Fabric. ' +
+          'Supported options are listed here: ' +
+          'https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/src/components/overlay/overlayModeEnum.ts');
+      }
+    });
+  };
 }
 
 /**
@@ -92,6 +90,6 @@ export class OverlayDirective implements angular.IDirective {
  *
  */
 export let module: angular.IModule = angular.module('officeuifabric.components.overlay', [
-    'officeuifabric.components'
+  'officeuifabric.components'
 ])
-    .directive('uifOverlay', OverlayDirective.factory());
+  .directive('uifOverlay', OverlayDirective.factory());

--- a/src/components/overlay/overlayModeEnum.ts
+++ b/src/components/overlay/overlayModeEnum.ts
@@ -1,8 +1,6 @@
-'use strict';
-
 /**
  * Enum for the modules supported by the Overlay directive.
- * 
+ *
  * @ngdoc enum
  * @readonly
  * @enum {string}

--- a/src/components/panel/panelDirective.spec.ts
+++ b/src/components/panel/panelDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 describe('panel: <uif-panel />', () => {
   beforeEach(() => {
     angular.mock.module('officeuifabric.core');
@@ -12,7 +10,7 @@ describe('panel: <uif-panel />', () => {
     let $scope: any;
 
     afterEach(() => {
-        this.$timeoutservice.verifyNoPendingTasks();
+      this.$timeoutservice.verifyNoPendingTasks();
     });
 
     beforeEach(inject(($rootScope: angular.IRootScopeService, $compile: Function, $timeout: angular.ITimeoutService) => {
@@ -97,16 +95,16 @@ describe('panel: <uif-panel />', () => {
       'clicking on the Overlay should not close the panel when no value is supplied to uif-is-light-dismiss',
       inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
 
-      $scope.isOpen = true;
-      $rootScope.$digest();
-      expect(panel).toHaveClass('is-open');
+        $scope.isOpen = true;
+        $rootScope.$digest();
+        expect(panel).toHaveClass('is-open');
 
-      // attempt to close the panel by clicking on the background overlay
-      panel.find('.ms-Overlay.ms-Overlay--dark').trigger('click');
-      $rootScope.$digest();
-      this.$timeoutservice.flush();
-      expect($scope.isOpen).toEqual(true);
-    }));
+        // attempt to close the panel by clicking on the background overlay
+        panel.find('.ms-Overlay.ms-Overlay--dark').trigger('click');
+        $rootScope.$digest();
+        this.$timeoutservice.flush();
+        expect($scope.isOpen).toEqual(true);
+      }));
 
   });
 
@@ -143,32 +141,32 @@ describe('panel: <uif-panel />', () => {
       'clicking on the Overlay should not close the panel when uif-is-light-dismiss is false',
       inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
 
-      $scope.isOpen = true;
-      $rootScope.$digest();
-      expect(panel).toHaveClass('is-open');
+        $scope.isOpen = true;
+        $rootScope.$digest();
+        expect(panel).toHaveClass('is-open');
 
-      // attempt to close the panel by clicking on the background overlay
-      panel.find('.ms-Overlay.ms-Overlay--dark').trigger('click');
-      $rootScope.$digest();
-      this.$timeoutservice.flush();
-      expect($scope.isOpen).toEqual(true);
-    }));
+        // attempt to close the panel by clicking on the background overlay
+        panel.find('.ms-Overlay.ms-Overlay--dark').trigger('click');
+        $rootScope.$digest();
+        this.$timeoutservice.flush();
+        expect($scope.isOpen).toEqual(true);
+      }));
 
     it(
       'clicking on the Overlay should close the panel when uif-is-light-dismiss is true',
       inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
 
-      $scope.isOpen = true;
-      $scope.isLightDismiss = true;
-      $rootScope.$digest();
-      expect(panel).toHaveClass('is-open');
+        $scope.isOpen = true;
+        $scope.isLightDismiss = true;
+        $rootScope.$digest();
+        expect(panel).toHaveClass('is-open');
 
-      // attempt to close the panel by clicking on the background overlay
-      panel.find('.ms-Overlay.ms-Overlay--dark').trigger('click');
-      $rootScope.$digest();
-      this.$timeoutservice.flush();
-      expect($scope.isOpen).toEqual(false);
-    }));
+        // attempt to close the panel by clicking on the background overlay
+        panel.find('.ms-Overlay.ms-Overlay--dark').trigger('click');
+        $rootScope.$digest();
+        this.$timeoutservice.flush();
+        expect($scope.isOpen).toEqual(false);
+      }));
 
   });
 
@@ -221,7 +219,7 @@ describe('panel: <uif-panel />', () => {
     }));
 
 
-    });
+  });
 
   describe('Ensure default is applied when no uif-type is supplied', () => {
     let panel: JQuery;

--- a/src/components/panel/panelDirective.ts
+++ b/src/components/panel/panelDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 import { PanelTypes } from './panelDirectiveEnum';
 

--- a/src/components/panel/panelDirectiveEnum.ts
+++ b/src/components/panel/panelDirectiveEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for all icons supported by Office UI Fabric. Enums in JavaScript are always number indexed, but this enum is
  * intended to be used as a striangular.

--- a/src/components/persona/personaDirective.spec.ts
+++ b/src/components/persona/personaDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('uif-persona', () => {

--- a/src/components/persona/personaDirective.ts
+++ b/src/components/persona/personaDirective.ts
@@ -1,10 +1,8 @@
-'use strict';
-
 import * as angular from 'angular';
-import {PersonaStyleEnum} from '../../core/personaStyleEnum';
-import {PresenceEnum} from '../../core/personaPresenceEnum';
-import {PersonaInitialsColor} from '../../core/personaInitialsColorEnum';
-import {PersonaSize} from './sizeEnum';
+import { PersonaStyleEnum } from '../../core/personaStyleEnum';
+import { PresenceEnum } from '../../core/personaPresenceEnum';
+import { PersonaInitialsColor } from '../../core/personaInitialsColorEnum';
+import { PersonaSize } from './sizeEnum';
 
 /**
  * @ngdoc directive

--- a/src/components/persona/sizeEnum.ts
+++ b/src/components/persona/sizeEnum.ts
@@ -1,6 +1,3 @@
-'use strict';
-
-
 /**
  * Enum for supported sizes of the Persona component.
  * This enum is intended to be used as a striangular.

--- a/src/components/personacard/personacardDirective.spec.ts
+++ b/src/components/personacard/personacardDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('uif-persona-card', () => {

--- a/src/components/personacard/personacardDirective.ts
+++ b/src/components/personacard/personacardDirective.ts
@@ -1,10 +1,8 @@
-'use strict';
-
 import * as angular from 'angular';
-import {PersonaSize} from './sizeEnum';
-import {PlaceholderEnum} from './placeholderEnum';
-import {PersonaStyleEnum} from '../../core/personaStyleEnum';
-import {PresenceEnum} from '../../core/personaPresenceEnum';
+import { PersonaSize } from './sizeEnum';
+import { PlaceholderEnum } from './placeholderEnum';
+import { PersonaStyleEnum } from '../../core/personaStyleEnum';
+import { PresenceEnum } from '../../core/personaPresenceEnum';
 
 /**
  * @ngdoc directive

--- a/src/components/personacard/placeholderEnum.ts
+++ b/src/components/personacard/placeholderEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 export enum PlaceholderEnum {
   regular,
   topright,

--- a/src/components/personacard/sizeEnum.ts
+++ b/src/components/personacard/sizeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 export enum PersonaSize {
   xsmall,
   small,

--- a/src/components/pivot/pivotDirective.spec.ts
+++ b/src/components/pivot/pivotDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('uif-pivot tests', () => {

--- a/src/components/pivot/pivotDirective.ts
+++ b/src/components/pivot/pivotDirective.ts
@@ -1,8 +1,6 @@
-'use strict';
-
 import * as angular from 'angular';
-import {PivotSize} from './pivotSizeEnum';
-import {PivotType} from './pivotTypeEnum';
+import { PivotSize } from './pivotSizeEnum';
+import { PivotType } from './pivotTypeEnum';
 
 /**
  * @ngdoc controller
@@ -41,7 +39,7 @@ export class PivotController {
  */
 export class PivotItem {
   public selected: boolean;
-  constructor(public title: string) {}
+  constructor(public title: string) { }
 }
 
 /**
@@ -66,8 +64,8 @@ export class PivotEllipsisDirective implements angular.IDirective {
   public transclude: boolean = true;
   public replace: boolean = false;
   public template: string = '<li class="ms-Pivot-link ms-Pivot-link--overflow">' +
-    '<uif-icon uif-type="ellipsis" class="ms-Pivot-ellipsis"></uif-icon>' +
-    '<ng-transclude></ng-transclude>' +
+  '<uif-icon uif-type="ellipsis" class="ms-Pivot-ellipsis"></uif-icon>' +
+  '<ng-transclude></ng-transclude>' +
   '</li>';
   public scope: boolean = false;
 
@@ -101,12 +99,12 @@ export class PivotDirective implements angular.IDirective {
   public controller: typeof PivotController = PivotController;
   public require: string[] = ['uifPivot'];
   public template: string = '<ul class="ms-Pivot" ng-class="getClasses()" >' +
-    '<span ng-repeat-start="pivot in uifPivots"></span>' +
-    '<li class="ms-Pivot-link" ng-click="pivotClick($index)" ' +
-      'ng-class="{\'is-selected\': pivot.selected}">{{pivot.title}}</li> ' +
-    '<span ng-repeat-end></span>' +
-    '<ng-transclude></ng-transclude>' +
-    '</ul>';
+  '<span ng-repeat-start="pivot in uifPivots"></span>' +
+  '<li class="ms-Pivot-link" ng-click="pivotClick($index)" ' +
+  'ng-class="{\'is-selected\': pivot.selected}">{{pivot.title}}</li> ' +
+  '<span ng-repeat-end></span>' +
+  '<ng-transclude></ng-transclude>' +
+  '</ul>';
 
   public scope: any = {
     uifPivots: '=?',

--- a/src/components/pivot/pivotSizeEnum.ts
+++ b/src/components/pivot/pivotSizeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  *
  * Enum for pivot sizes supported by Office UI Fabric.

--- a/src/components/pivot/pivotTypeEnum.ts
+++ b/src/components/pivot/pivotTypeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  *
  * Enum for pivot type supported by Office UI Fabric.

--- a/src/components/progressindicator/progressIndicatorDirective.spec.ts
+++ b/src/components/progressindicator/progressIndicatorDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('progressIndicatorDirective: <uif-progress-indicator />', () => {

--- a/src/components/progressindicator/progressIndicatorDirective.ts
+++ b/src/components/progressindicator/progressIndicatorDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 /**

--- a/src/components/searchbox/searchboxDirective.spec.ts
+++ b/src/components/searchbox/searchboxDirective.spec.ts
@@ -1,171 +1,169 @@
-﻿'use strict';
-
-import * as angular from 'angular';
+﻿import * as angular from 'angular';
 
 describe('searchBoxDirective: <uif-searchbox />', () => {
-    let element: JQuery;
-    let scope: angular.IScope;
-    beforeEach(() => {
-        angular.mock.module('officeuifabric.core');
-        angular.mock.module('officeuifabric.components.searchbox');
-    });
-    beforeEach(inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        element = angular.element('<uif-searchbox value="\'value\'" />');
-        scope = $rootScope;
-        $compile(element)(scope);
-        scope.$digest();
-        element = jQuery(element[0]);
-    }));
+  let element: JQuery;
+  let scope: angular.IScope;
+  beforeEach(() => {
+    angular.mock.module('officeuifabric.core');
+    angular.mock.module('officeuifabric.components.searchbox');
+  });
+  beforeEach(inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    element = angular.element('<uif-searchbox value="\'value\'" />');
+    scope = $rootScope;
+    $compile(element)(scope);
+    scope.$digest();
+    element = jQuery(element[0]);
+  }));
 
-    afterEach(() => {
-        // myfunc.reset();
-    });
-    it('should render correct HTML', () => {
-        let elem: JQuery = element.find('input');
-        expect(elem.length).toBe(1);
-    });
+  afterEach(() => {
+    // myfunc.reset();
+  });
+  it('should render correct HTML', () => {
+    let elem: JQuery = element.find('input');
+    expect(elem.length).toBe(1);
+  });
 
-    it('should have unique ids', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
-        let $scope: angular.IScope = $rootScope.$new();
-        let textBox1: JQuery = $compile('<uif-searchbox ></uif-searchbox>')($scope);
-        textBox1 = jQuery(textBox1[0]);
-        $scope.$digest();
-        let textField1: JQuery = textBox1.find('.ms-SearchBox-field');
-        let textBox2: JQuery = $compile('<uif-searchbox ></uif-searchbox>')($scope);
-        textBox2 = jQuery(textBox2[0]);
-        $scope.$digest();
-        let textField2: JQuery = textBox2.find('.ms-SearchBox-field');
-        expect(textField1[0].id === textField2[0].id).toBe(false);
-    }));
-    it('should be able to set value', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        let $newScope: any = $rootScope.$new();
-        $newScope.value = 'Value';
-        let tag: JQuery = angular.element('<uif-searchbox ng-model="value" />');
-        $compile(tag)($newScope);
-        $newScope.$digest();
-        tag = jQuery(tag[0]);
-        expect(tag.find('.ms-SearchBox-field').val()).toBe('Value');
-    }));
-    it('hide label', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        let $newScope: angular.IScope = $rootScope.$new();
-        let jqlTag: JQuery = angular.element('<uif-searchbox />'); // jqlite
-        $compile(jqlTag)($newScope);
-        $newScope.$digest();
-        let jqTag: JQuery = jQuery(jqlTag[0]); // jquery
+  it('should have unique ids', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
+    let $scope: angular.IScope = $rootScope.$new();
+    let textBox1: JQuery = $compile('<uif-searchbox ></uif-searchbox>')($scope);
+    textBox1 = jQuery(textBox1[0]);
+    $scope.$digest();
+    let textField1: JQuery = textBox1.find('.ms-SearchBox-field');
+    let textBox2: JQuery = $compile('<uif-searchbox ></uif-searchbox>')($scope);
+    textBox2 = jQuery(textBox2[0]);
+    $scope.$digest();
+    let textField2: JQuery = textBox2.find('.ms-SearchBox-field');
+    expect(textField1[0].id === textField2[0].id).toBe(false);
+  }));
+  it('should be able to set value', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    let $newScope: any = $rootScope.$new();
+    $newScope.value = 'Value';
+    let tag: JQuery = angular.element('<uif-searchbox ng-model="value" />');
+    $compile(tag)($newScope);
+    $newScope.$digest();
+    tag = jQuery(tag[0]);
+    expect(tag.find('.ms-SearchBox-field').val()).toBe('Value');
+  }));
+  it('hide label', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    let $newScope: angular.IScope = $rootScope.$new();
+    let jqlTag: JQuery = angular.element('<uif-searchbox />'); // jqlite
+    $compile(jqlTag)($newScope);
+    $newScope.$digest();
+    let jqTag: JQuery = jQuery(jqlTag[0]); // jquery
 
-        // trigger events on jqLite element
-        jqlTag.find('input').triggerHandler('focus');
-        $newScope.$digest();
-        expect(jqTag.find('.ms-SearchBox-label').hasClass('ng-hide')).toBe(true);
-        jqlTag.find('input').triggerHandler('blur');
-        $newScope.$digest();
-        expect(jqTag.find('.ms-SearchBox-label').hasClass('ng-hide')).toBe(false);
-    }));
+    // trigger events on jqLite element
+    jqlTag.find('input').triggerHandler('focus');
+    $newScope.$digest();
+    expect(jqTag.find('.ms-SearchBox-label').hasClass('ng-hide')).toBe(true);
+    jqlTag.find('input').triggerHandler('blur');
+    $newScope.$digest();
+    expect(jqTag.find('.ms-SearchBox-label').hasClass('ng-hide')).toBe(false);
+  }));
 
-    it('should toggle disable', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        let $newScope: any = $rootScope.$new();
-        $newScope.disabled = false;
+  it('should toggle disable', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    let $newScope: any = $rootScope.$new();
+    $newScope.disabled = false;
 
-        let jqlTag: JQuery = angular.element('<uif-searchbox ng-disabled="disabled"/>'); // jqlite
-        $compile(jqlTag)($newScope);
-        $newScope.$digest();
+    let jqlTag: JQuery = angular.element('<uif-searchbox ng-disabled="disabled"/>'); // jqlite
+    $compile(jqlTag)($newScope);
+    $newScope.$digest();
 
-        let jqTag: JQuery = jQuery(jqlTag[0]); // jquery
+    let jqTag: JQuery = jQuery(jqlTag[0]); // jquery
 
-        let div: JQuery = jqTag.find('.ms-SearchBox');
-        let input: JQuery = jqTag.find('.ms-SearchBox-field');
+    let div: JQuery = jqTag.find('.ms-SearchBox');
+    let input: JQuery = jqTag.find('.ms-SearchBox-field');
 
-        expect(input.attr('disabled')).toBe(undefined, 'Input should not be disabled.');
-        expect(div).not.toHaveClass('is-disabled');
+    expect(input.attr('disabled')).toBe(undefined, 'Input should not be disabled.');
+    expect(div).not.toHaveClass('is-disabled');
 
-        // toggle disabled
-        $newScope.disabled = true;
-        $newScope.$digest();
+    // toggle disabled
+    $newScope.disabled = true;
+    $newScope.$digest();
 
-        expect(input.attr('disabled')).toBe('disabled', 'Input should be disabled.');
-        expect(div).toHaveClass('is-disabled');
-    }));
+    expect(input.attr('disabled')).toBe('disabled', 'Input should be disabled.');
+    expect(div).toHaveClass('is-disabled');
+  }));
 
-    it('should be initially disabled', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        let $newScope: any = $rootScope.$new();
-        $newScope.disabled = false;
+  it('should be initially disabled', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    let $newScope: any = $rootScope.$new();
+    $newScope.disabled = false;
 
-        let jqlTag: JQuery = angular.element('<uif-searchbox disabled="disabled"/>'); // jqlite
-        $compile(jqlTag)($newScope);
-        $newScope.$digest();
+    let jqlTag: JQuery = angular.element('<uif-searchbox disabled="disabled"/>'); // jqlite
+    $compile(jqlTag)($newScope);
+    $newScope.$digest();
 
-        let jqTag: JQuery = jQuery(jqlTag[0]); // jquery
+    let jqTag: JQuery = jQuery(jqlTag[0]); // jquery
 
-        let input: JQuery = jqTag.find('.ms-SearchBox-field');
-        let div: JQuery = jqTag.find('.ms-SearchBox');
+    let input: JQuery = jqTag.find('.ms-SearchBox-field');
+    let div: JQuery = jqTag.find('.ms-SearchBox');
 
-        expect(input.attr('disabled')).toBe('disabled', 'Input should be disabled.');
-        expect(div).toHaveClass('is-disabled');
-    }));
+    expect(input.attr('disabled')).toBe('disabled', 'Input should be disabled.');
+    expect(div).toHaveClass('is-disabled');
+  }));
 
-    it('should set $dirty value changed', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        let $newScope: any = $rootScope.$new();
-        $newScope.value = 'Value';
+  it('should set $dirty value changed', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    let $newScope: any = $rootScope.$new();
+    $newScope.value = 'Value';
 
-        let tag: JQuery = angular.element('<uif-searchbox ng-model="value" />');
-        $compile(tag)($newScope);
-        $newScope.$digest();
-        tag = jQuery(tag[0]);
+    let tag: JQuery = angular.element('<uif-searchbox ng-model="value" />');
+    $compile(tag)($newScope);
+    $newScope.$digest();
+    tag = jQuery(tag[0]);
 
-        let ngModel: angular.INgModelController = angular.element(tag).controller('ngModel');
-        expect(ngModel.$dirty).toBe(false);
+    let ngModel: angular.INgModelController = angular.element(tag).controller('ngModel');
+    expect(ngModel.$dirty).toBe(false);
 
-        let input: JQuery = tag.find('.ms-SearchBox-field');
+    let input: JQuery = tag.find('.ms-SearchBox-field');
 
-        input.val('Value changed');
-        angular.element(input).triggerHandler('input');
+    input.val('Value changed');
+    angular.element(input).triggerHandler('input');
 
-        $newScope.$digest();
+    $newScope.$digest();
 
-        expect(ngModel.$dirty).toBe(true);
-    }));
+    expect(ngModel.$dirty).toBe(true);
+  }));
 
-    it('should set $touched on blur', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        let $newScope: any = $rootScope.$new();
-        $newScope.value = 'Value';
+  it('should set $touched on blur', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    let $newScope: any = $rootScope.$new();
+    $newScope.value = 'Value';
 
-        let tag: JQuery = angular.element('<uif-searchbox ng-model="value" />');
-        $compile(tag)($newScope);
-        $newScope.$digest();
-        tag = jQuery(tag[0]);
+    let tag: JQuery = angular.element('<uif-searchbox ng-model="value" />');
+    $compile(tag)($newScope);
+    $newScope.$digest();
+    tag = jQuery(tag[0]);
 
-        let ngModel: angular.INgModelController = angular.element(tag).controller('ngModel');
-        expect(ngModel.$touched).toBe(false);
+    let ngModel: angular.INgModelController = angular.element(tag).controller('ngModel');
+    expect(ngModel.$touched).toBe(false);
 
-        let input: JQuery = tag.find('.ms-SearchBox-field');
-        angular.element(input).triggerHandler('blur');
+    let input: JQuery = tag.find('.ms-SearchBox-field');
+    angular.element(input).triggerHandler('blur');
 
-        $newScope.$digest();
+    $newScope.$digest();
 
-        expect(ngModel.$touched).toBe(true);
-    }));
+    expect(ngModel.$touched).toBe(true);
+  }));
 
-    it('when cleared, $dirty should be set', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
-        let $newScope: any = $rootScope.$new();
-        $newScope.value = 'Value';
+  it('when cleared, $dirty should be set', inject(($rootScope: angular.IRootScopeService, $compile: Function) => {
+    let $newScope: any = $rootScope.$new();
+    $newScope.value = 'Value';
 
-        let tag: JQuery = angular.element('<uif-searchbox ng-model="value" />');
-        $compile(tag)($newScope);
-        $newScope.$digest();
-        tag = jQuery(tag[0]);
+    let tag: JQuery = angular.element('<uif-searchbox ng-model="value" />');
+    $compile(tag)($newScope);
+    $newScope.$digest();
+    tag = jQuery(tag[0]);
 
-        let ngModel: angular.INgModelController = angular.element(tag).controller('ngModel');
-        expect(ngModel.$dirty).toBe(false);
+    let ngModel: angular.INgModelController = angular.element(tag).controller('ngModel');
+    expect(ngModel.$dirty).toBe(false);
 
-        let input: JQuery = tag.find('.ms-SearchBox-field');
-        let button: JQuery = tag.find('.ms-SearchBox-closeButton');
+    let input: JQuery = tag.find('.ms-SearchBox-field');
+    let button: JQuery = tag.find('.ms-SearchBox-closeButton');
 
-        angular.element(button).triggerHandler('mousedown');
-        angular.element(input).triggerHandler('blur');
+    angular.element(button).triggerHandler('mousedown');
+    angular.element(input).triggerHandler('blur');
 
-        $newScope.$digest();
+    $newScope.$digest();
 
-        expect($newScope.value).toBe('');
-        expect(ngModel.$dirty).toBe(true);
-    }));
+    expect($newScope.value).toBe('');
+    expect(ngModel.$dirty).toBe(true);
+  }));
 });

--- a/src/components/searchbox/searchboxDirective.ts
+++ b/src/components/searchbox/searchboxDirective.ts
@@ -1,5 +1,4 @@
-﻿'use strict';
-import * as angular from 'angular';
+﻿import * as angular from 'angular';
 
 /**
  * @ngdoc interface
@@ -13,7 +12,6 @@ import * as angular from 'angular';
  * @property {string} value       - The scope variable to bind to the text input.
  */
 interface ISearchBoxScope extends angular.IScope {
-
   btnMousedown: () => void;
   inputFocus: () => void;
   inputBlur: () => void;
@@ -26,6 +24,7 @@ interface ISearchBoxScope extends angular.IScope {
   placeholder: string;
   value: string;
 }
+
 /**
  * @ngdoc directive
  * @name uifSearchbox

--- a/src/components/spinner/spinnerDirective.spec.ts
+++ b/src/components/spinner/spinnerDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('spinnerDirective: <uif-spinner />', () => {

--- a/src/components/spinner/spinnerDirective.ts
+++ b/src/components/spinner/spinnerDirective.ts
@@ -1,6 +1,5 @@
-'use strict';
 import * as angular from 'angular';
-import {SpinnerSize} from './spinnerSizeEnum';
+import { SpinnerSize } from './spinnerSizeEnum';
 
 /**
  * @ngdoc directive
@@ -27,7 +26,7 @@ export class SpinnerDirective implements angular.IDirective {
   public controller: any = SpinnerController;
   public scope: any = {
     'ngShow': '=',
-    'uifSize' : '@'
+    'uifSize': '@'
   };
 
   public static factory(): angular.IDirectiveFactory {
@@ -42,39 +41,39 @@ export class SpinnerDirective implements angular.IDirective {
     controller: SpinnerController,
     $transclude: angular.ITranscludeFunction): void {
 
-      if (angular.isDefined(attrs.uifSize) ) {
-        if (angular.isUndefined(SpinnerSize[attrs.uifSize])) {
+    if (angular.isDefined(attrs.uifSize)) {
+      if (angular.isUndefined(SpinnerSize[attrs.uifSize])) {
 
         controller.$log.error('Error [ngOfficeUiFabric] officeuifabric.components.spinner - Unsupported size: ' +
           'Spinner size (\'' + attrs.uifSize + '\') is not supported by the Office UI Fabric.');
-        }
-
-        if (SpinnerSize[attrs.uifSize] === SpinnerSize.large) {
-          instanceElement.addClass('ms-Spinner--large');
-        }
       }
 
-      if (attrs.ngShow != null) {
-        scope.$watch('ngShow', (newVisible: boolean, oldVisible: boolean, spinnerScope: ISpinnerScope): void => {
-            if (newVisible) {
-              spinnerScope.start();
-            } else {
-              spinnerScope.stop();
-            }
-        });
-      } else {
-        scope.start();
+      if (SpinnerSize[attrs.uifSize] === SpinnerSize.large) {
+        instanceElement.addClass('ms-Spinner--large');
       }
+    }
 
-      $transclude((clone: angular.IAugmentedJQuery) => {
-        if (clone.length > 0) {
-          let wrapper: angular.IAugmentedJQuery = angular.element('<div></div>');
-          wrapper.addClass('ms-Spinner-label').append(clone);
-          instanceElement.append(wrapper);
+    if (attrs.ngShow != null) {
+      scope.$watch('ngShow', (newVisible: boolean, oldVisible: boolean, spinnerScope: ISpinnerScope): void => {
+        if (newVisible) {
+          spinnerScope.start();
+        } else {
+          spinnerScope.stop();
         }
       });
+    } else {
+      scope.start();
+    }
 
-      scope.init();
+    $transclude((clone: angular.IAugmentedJQuery) => {
+      if (clone.length > 0) {
+        let wrapper: angular.IAugmentedJQuery = angular.element('<div></div>');
+        wrapper.addClass('ms-Spinner-label').append(clone);
+        instanceElement.append(wrapper);
+      }
+    });
+
+    scope.init();
   }
 }
 
@@ -133,13 +132,13 @@ class SpinnerController {
 
     $scope.start = (): void => {
       this._animationInterval = $interval(
-      () => {
-        let i: number = this._circles.length;
-        while (i--) {
-          this.fadeCircle(this._circles[i]);
-        }
-       },
-      this._animationSpeed);
+        () => {
+          let i: number = this._circles.length;
+          while (i--) {
+            this.fadeCircle(this._circles[i]);
+          }
+        },
+        this._animationSpeed);
     };
 
     $scope.stop = (): void => {
@@ -183,13 +182,13 @@ class SpinnerController {
 
   private setInitialOpacity(): void {
 
-        let opcaityToSet: number;
-        this._fadeIncrement = 1 / this._numCircles;
+    let opcaityToSet: number;
+    this._fadeIncrement = 1 / this._numCircles;
 
-        this._circles.forEach((circle: CircleObject, index: number) => {
-          opcaityToSet = (this._fadeIncrement * (index + 1));
-          circle.opacity = opcaityToSet;
-        });
+    this._circles.forEach((circle: CircleObject, index: number) => {
+      opcaityToSet = (this._fadeIncrement * (index + 1));
+      circle.opacity = opcaityToSet;
+    });
   }
 
   private fadeCircle(circle: CircleObject): void {

--- a/src/components/spinner/spinnerSizeEnum.ts
+++ b/src/components/spinner/spinnerSizeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  *
  * Enum for spinner sizes supported by Office UI Fabric.

--- a/src/components/table/tableDirective.spec.ts
+++ b/src/components/table/tableDirective.spec.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 describe('tableDirective: <uif-table />', () => {

--- a/src/components/table/tableDirective.ts
+++ b/src/components/table/tableDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 import { TableRowSelectModeEnum } from './tableRowSelectModeEnum';
 import { TableTypeEnum } from './tableTypeEnum';

--- a/src/components/table/tableRowSelectModeEnum.ts
+++ b/src/components/table/tableRowSelectModeEnum.ts
@@ -1,12 +1,10 @@
-'use strict';
-
 /**
  * Enumeration of the different row selection modes supported by the table directive.
- * 
+ *
  * @readonly
  * @enum {string}
  * @usage
- * 
+ *
  * This enumeration is used to specify which row selection mode the table should use.
  */
 export enum TableRowSelectModeEnum {

--- a/src/components/table/tableTypeEnum.ts
+++ b/src/components/table/tableTypeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for supported input types of the uif-table directive
  * This enum is intended to be used as a striangular.

--- a/src/components/textfield/textFieldDirective.ts
+++ b/src/components/textfield/textFieldDirective.ts
@@ -1,6 +1,5 @@
-﻿'use strict';
-
 import * as angular from 'angular';
+
 import { InputTypeEnum } from './uifTypeEnum';
 
 /**

--- a/src/components/textfield/uifTypeEnum.ts
+++ b/src/components/textfield/uifTypeEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for supported input types of the uif-textfield directive
  * This enum is intended to be used as a striangular.

--- a/src/components/toggle/toggleDirective.ts
+++ b/src/components/toggle/toggleDirective.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 
 /**

--- a/src/core/components.ts
+++ b/src/core/components.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import * as angular from 'angular';
 import * as breadcrumbModule from '../components/breadcrumb/breadcrumbDirective';
 import * as buttonModule from '../components/button/buttonDirective';

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -1,6 +1,4 @@
-﻿'use strict';
-
-import * as angular from 'angular';
+﻿import * as angular from 'angular';
 
 /**
  * @ngdoc module

--- a/src/core/personaInitialsColorEnum.ts
+++ b/src/core/personaInitialsColorEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for supported initials color of persona-based components, Persona, PersonaCard & OrgChart.
  * This enum is intended to be used as a striangular.

--- a/src/core/personaPresenceEnum.ts
+++ b/src/core/personaPresenceEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for supported presence statuses of persona-based components: Persona, PersonaCard & OrgChart.
  * This enum is intended to be used as a striangular.

--- a/src/core/personaStyleEnum.ts
+++ b/src/core/personaStyleEnum.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Enum for supported styles of persona-based components: Persona, PersonaCard & OrgChart.
  * This enum is intended to be used as a striangular.


### PR DESCRIPTION
Formatted all TypeScript code to match what style rules used in the `tslint.json`. Also removed all `use strict` statements from TypeScript files as unnecessary.
