### PR TITLE
fix(peoplePicker): don't remove selected people if disabled

### DIFF
--- a/src/components/peoplepicker/peoplePickerDirective.spec.ts
+++ b/src/components/peoplepicker/peoplePickerDirective.spec.ts
@@ -205,7 +205,6 @@ describe('peoplepicker: <uif-people-picker />', () => {
     }));
 
     it('should add person to selected', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
-
       let $searchInput: JQuery = $element.find('input.ms-PeoplePicker-searchField').first();
       $searchInput.click();
       $scope.$apply();
@@ -218,7 +217,6 @@ describe('peoplepicker: <uif-people-picker />', () => {
     }));
 
     it('should not add person to selected twice', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
-
       let $searchInput: JQuery = $element.find('input.ms-PeoplePicker-searchField').first();
       $searchInput.click();
       $scope.$apply();
@@ -234,7 +232,6 @@ describe('peoplepicker: <uif-people-picker />', () => {
     }));
 
     it('should remove person from selected', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
-
       let $searchInput: JQuery = $element.find('input.ms-PeoplePicker-searchField').first();
       $searchInput.click();
       $scope.$apply();
@@ -250,8 +247,25 @@ describe('peoplepicker: <uif-people-picker />', () => {
       expect($scope.selectedPeople.length).toBe(0);
     }));
 
-    it('should remove person from search results', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
+    it('should not remove person from selected if disabled', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
+      $scope.disabled = true;
+      $scope.$apply();
+      let $searchInput: JQuery = $element.find('input.ms-PeoplePicker-searchField').first();
+      $searchInput.click();
+      $scope.$apply();
+      let $btn: JQuery = $element.find('.ms-PeoplePicker-resultBtn').first();
 
+      $btn.click();
+      $scope.$apply();
+
+      let $personRemove: JQuery = $element.find('.ms-PeoplePicker-persona .ms-PeoplePicker-personaRemove');
+      $personRemove.click();
+      $scope.$apply();
+
+      expect($scope.selectedPeople.length).not.toBe(0);
+    }));
+
+    it('should remove person from search results', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
       let $searchResultCloseBtn: JQuery = $element.find('.ms-PeoplePicker-resultAction.js-resultRemove').last();
       $searchResultCloseBtn.click();
       $scope.$apply();

--- a/src/components/peoplepicker/peoplePickerDirective.ts
+++ b/src/components/peoplepicker/peoplePickerDirective.ts
@@ -519,10 +519,11 @@ export class PeoplePickerDirective implements angular.IDirective {
     };
 
     $scope.removePersonFromSelectedPeople = (person: IPersonPicker, $event: MouseEvent) => {
-      let indx: number = $scope.selectedPersons.indexOf(person);
-      $scope.selectedPersons.splice(indx, 1);
-      ngModelCtrl.$setViewValue($scope.selectedPersons);
-
+      if (!$scope.ngDisabled) {
+        let indx: number = $scope.selectedPersons.indexOf(person);
+        $scope.selectedPersons.splice(indx, 1);
+        ngModelCtrl.$setViewValue($scope.selectedPersons);
+      }
       $event.stopPropagation();
     };
 


### PR DESCRIPTION
Disabled the ability to **remove selected** people if the people picker itself is in **disabled** state.

Closes #461 