### PR TITLE
fix(callout): uifArrow optional

### DIFF
--- a/src/components/callout/calloutDirective.spec.ts
+++ b/src/components/callout/calloutDirective.spec.ts
@@ -66,10 +66,13 @@ describe('calloutDirectives:', () => {
       expect(parentElement[0]).toHaveClass('ms-Callout-main');
     });
 
-    it('plain callout should have left arrow', () => {
+    it('plain callout should have no arrow', () => {
       let calloutElement: JQuery = element.find('div').first();
 
-      expect(calloutElement[0]).toHaveClass('ms-Callout--arrowLeft');
+      expect(calloutElement[0]).not.toHaveClass('ms-Callout--arrowRight');
+      expect(calloutElement[0]).not.toHaveClass('ms-Callout--arrowLeft');
+      expect(calloutElement[0]).not.toHaveClass('ms-Callout--arrowTop');
+      expect(calloutElement[0]).not.toHaveClass('ms-Callout--arrowBottom');
     });
 
     it(
@@ -97,7 +100,7 @@ describe('calloutDirectives:', () => {
       }));
 
     it(
-      'empty arrow attribute logs error',
+      'empty arrow attribute log error',
       inject(($rootScope: angular.IRootScopeService, $compile: angular.ICompileService, $log: angular.ILogService) => {
         element = angular.element('<uif-callout uif-arrow></uif-callout>');
         scope = $rootScope;
@@ -105,8 +108,7 @@ describe('calloutDirectives:', () => {
         scope.$digest();
 
         expect($log.error.logs[0]).toContain('Error [ngOfficeUiFabric] officeuifabric.components.callout - "' +
-          '" is not a valid value for uifArrow. It should be left, right, top, bottom.');
-        // expect(calloutElement[0]).toHaveClass('ms-Callout--arrowLeft');
+           '" is not a valid value for uifArrow. It should be left, right, top, bottom.');
       }));
 
     it(

--- a/src/components/callout/demo/index.html
+++ b/src/components/callout/demo/index.html
@@ -43,6 +43,29 @@
     </uif-callout>
   </p>
 
+  <p>uifArrow attribute is optional. If not provided, callout does not have arrow.
+    <br/>
+    <pre>
+    &lt;uif-callout&gt;
+      &lt;uif-callout-header&gt;All of your favorite people&lt;/uif-callout-header&gt;
+      &lt;uif-callout-content&gt;Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.&lt;/uif-callout-content&gt;
+      &lt;uif-callout-actions&gt;
+        &lt;a href=&quot;#&quot; class=&quot;ms-Callout-link ms-Link ms-Link--hero&quot;&gt;Learn more&lt;/a&gt;
+      &lt;/uif-callout-actions&gt;
+    &lt;/uif-callout&gt;
+    </pre>
+  </p>
+
+  <p>
+    <uif-callout>
+      <uif-callout-header>All of your favorite people</uif-callout-header>
+      <uif-callout-content>Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.</uif-callout-content>
+      <uif-callout-actions>
+        <a href="#" class="ms-Callout-link ms-Link ms-Link--hero">Learn more</a>
+      </uif-callout-actions>
+    </uif-callout>
+  </p>
+
   <!-- second example -->
   <p>
     This markup will render OOBE callout:


### PR DESCRIPTION
`uifArrow` attribute on the scope optional. If not specified, no decoration is applied.
Closes #477 