### PR TITLE
Angular 1.6 #431

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
     "commit": "git-cz"
   },
   "dependencies": {
-    "angular": "1.5.8",
+    "angular": "1.6.2",
     "office-ui-fabric": "2.6.2"
   },
   "devDependencies": {
-    "@types/angular": "1.5.20",
-    "@types/angular-animate": "1.5.5",
-    "@types/angular-mocks": "1.5.6",
+    "@types/angular": "1.6.7",
+    "@types/angular-animate": "1.5.6",
+    "@types/angular-mocks": "1.5.9",
     "@types/bluebird": "3.0.37",
     "@types/browser-sync": "0.0.34",
     "@types/chalk": "0.4.31",
@@ -98,9 +98,9 @@
     "@types/webpack": "2.2.6",
     "@types/xmldom": "^0.1.28",
     "@types/yargs": "6.6.0",
-    "angular-animate": "1.5.8",
-    "angular-mocks": "1.5.8",
-    "angular-sanitize": "1.5.8",
+    "angular-animate": "1.6.2",
+    "angular-mocks": "1.6.2",
+    "angular-sanitize": "1.6.2",
     "browser-sync": "2.18.8",
     "chalk": "1.1.3",
     "commitizen": "2.9.6",

--- a/src/components/button/buttonDirective.spec.ts
+++ b/src/components/button/buttonDirective.spec.ts
@@ -50,9 +50,9 @@ describe('buttonDirective: <uif-button />', () => {
       // expected rendered HTML:
       // <span class="ms-Button-description">Lorem Ipsum</span>
 
-      // check value of the span
-      let spanElement: JQuery = element.find('span');
-      expect(spanElement[0].innerText).toBe('Lorem Ipsum');
+      // check value of the element
+      expect(element[0].tagName).toBe('SPAN');
+      expect(element[0].innerText).toBe('Lorem Ipsum');
     });
   });
 

--- a/src/components/button/buttonDirective.ts
+++ b/src/components/button/buttonDirective.ts
@@ -200,7 +200,7 @@ export class ButtonDirective implements angular.IDirective {
         case ButtonTypeEnum[ButtonTypeEnum.command]:
           for (let i: number = 0; i < clone.length; i++) {
             // wrap the button label
-            if (clone[i].tagName === 'SPAN') {
+            if (this._isValidLabel(clone[i])) {
               wrapper = angular.element('<span></span>');
               wrapper.addClass('ms-Button-label').append(clone[i]);
               element.append(wrapper);
@@ -216,14 +216,13 @@ export class ButtonDirective implements angular.IDirective {
         // if type === compound
         case ButtonTypeEnum[ButtonTypeEnum.compound]:
           for (let i: number = 0; i < clone.length; i++) {
-            // if not a span, stop checkiangular...
-            if (clone[i].tagName !== 'SPAN') {
+            // icon is not supported on compound button
+            if (clone[i].tagName === 'UIF-ICON') {
               continue;
             }
 
             // wrap the button label
-            if (clone[i].classList[0] === 'ng-scope' &&
-              clone[i].classList.length === 1) {
+            if (this._isValidLabel(clone[i])) {
               wrapper = angular.element('<span></span>');
               wrapper.addClass('ms-Button-label').append(clone[i]);
               element.append(wrapper);
@@ -237,7 +236,7 @@ export class ButtonDirective implements angular.IDirective {
         case ButtonTypeEnum[ButtonTypeEnum.hero]:
           for (let i: number = 0; i < clone.length; i++) {
             // wrap the label
-            if (clone[i].tagName === 'SPAN') {
+            if (this._isValidLabel(clone[i])) {
               wrapper = angular.element('<span></span>');
               wrapper.addClass('ms-Button-label').append(clone[i]);
               element.append(wrapper);
@@ -255,6 +254,10 @@ export class ButtonDirective implements angular.IDirective {
       }
     });
 
+  }
+
+  private _isValidLabel(clone: HTMLElement): boolean {
+    return clone.nodeType === Node.TEXT_NODE && clone.nodeValue.trim().length > 0;
   }
 
   private _populateHtmlTemplates(): void {

--- a/src/components/callout/calloutDirective.spec.ts
+++ b/src/components/callout/calloutDirective.spec.ts
@@ -610,11 +610,6 @@ describe('calloutDirectives:', () => {
       let firstActionSpans: JQuery = firstAction.children('span');
       expect(firstActionSpans.length).toBe(2);
       expect(firstActionSpans).toHaveClass('ms-Callout-actionText');
-
-      // deepest span should not have the ms-Callout-actionText class
-      let deepestSpan: JQuery = firstActionSpans.children('span');
-      expect(deepestSpan.length).toBe(1);
-      expect(deepestSpan).not.toHaveClass('ms-Callout-actionText');
     }));
 
     it('clicking close button inside callout actions directive closes callout', inject(($compile: angular.ICompileService) => {

--- a/src/components/choicefield/choicefieldDirective.spec.ts
+++ b/src/components/choicefield/choicefieldDirective.spec.ts
@@ -33,7 +33,7 @@ describe('choicefieldDirective <uif-choicefield />', () => {
     let input1: JQuery = jQuery(items[0]);
     expect(input1.attr('type')).toBe('radio', 'Type should be radio');
 
-    let span1: JQuery = container.find('label[for="' + input1.attr('id') + '"] span span.ng-scope');
+    let span1: JQuery = container.find('label[for="' + input1.attr('id') + '"] span');
     expect(span1.html()).toBe('Text 1', 'Label should be Text 1');
   }));
 

--- a/src/components/dropdown/dropdownDirective.spec.ts
+++ b/src/components/dropdown/dropdownDirective.spec.ts
@@ -59,6 +59,7 @@
         $('html').click();
         expect(div.hasClass('is-open')).toBe(false, 'Should not have class is-open after click on HTML');
     }));
+
     it('should be able to select an option', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {
         let $scope: any = $rootScope.$new();
         $scope.options = [

--- a/src/components/dropdown/dropdownDirective.ts
+++ b/src/components/dropdown/dropdownDirective.ts
@@ -68,7 +68,7 @@ export class DropdownOptionDirective implements angular.IDirective {
     instanceElement
       .on('click', (ev: JQueryEventObject) => {
         scope.$apply(() => {
-          dropdownController.setViewValue(instanceElement.find('span').html(), attrs.value, ev);
+          dropdownController.setViewValue(instanceElement.html(), attrs.value, ev);
         });
       });
     let value: string = '' + dropdownController.getViewValue();
@@ -129,7 +129,7 @@ export class DropdownController {
           let option: HTMLElement = options[i];
           let value: string = option.getAttribute('value');
           if (value === self.$scope.ngModel.$viewValue) {
-            self.$scope.selectedTitle = angular.element(option).find('span').html();
+            self.$scope.selectedTitle = angular.element(option).html();
             found = true;
             break;
           }

--- a/src/components/messagebanner/messageBannerDirective.spec.ts
+++ b/src/components/messagebanner/messageBannerDirective.spec.ts
@@ -38,7 +38,7 @@ describe('messageBannerDirective: <uif-message-banner />', () => {
     it('should be able to render ui-content message', (): void => {
         $scope.message = 'Lorem ipsum message';
         $scope.$digest();
-        let content: JQuery = $element.find('.uif-content>span.ng-scope');
+        let content: JQuery = $element.find('span.uif-content');
         expect(content.html()).toContain('Lorem ipsum message', 'Message should be placed in uif-content block.');
     });
 

--- a/src/components/messagebar/messageBarDirective.spec.ts
+++ b/src/components/messagebar/messageBarDirective.spec.ts
@@ -39,7 +39,9 @@ describe('messageBarDirective: <uif-message-bar />', () => {
     it('should be able to render uif-content message', (): void => {
         $scope.message = 'Lorem ipsum message';
         $scope.$digest();
-        let content: JQuery = $element.find('.uif-content>span.ng-scope');
+
+        let content: JQuery = $element.find('span.uif-content');
+
         expect(content.html()).toContain('Lorem ipsum message', 'Message should be placed in uif-content block.');
     });
 

--- a/src/components/table/tableDirective.spec.ts
+++ b/src/components/table/tableDirective.spec.ts
@@ -221,9 +221,10 @@ describe('tableDirective: <uif-table />', () => {
     scope.$digest();
 
     let fileNameHeader: JQuery = element.children().eq(0).children().eq(1);
+
     fileNameHeader.click();
     fileNameHeader.click();
-    let sortingIndicatorWrapper: JQuery = fileNameHeader.children().eq(1);
+    let sortingIndicatorWrapper: JQuery = fileNameHeader.children().eq(0);
     let sortingIndicator: JQuery = sortingIndicatorWrapper.children().eq(0);
     expect(sortingIndicator).toHaveClass('ms-Icon--caretUp');
   }));
@@ -273,8 +274,8 @@ describe('tableDirective: <uif-table />', () => {
       let fileNameHeader: JQuery = element.children().eq(0).children().eq(1);
       idHeader.click(); // sort id:asc
       fileNameHeader.click(); // sort fileName:asc
-      expect(idHeader.children().length).toEqual(1, 'Sorting indicator not removed from column previously used for sorting');
-      expect(fileNameHeader.children().length).toEqual(2, 'Sorting indicator not added to the column used for sorting');
+      expect(idHeader.children().length).toEqual(0, 'Sorting indicator not removed from column previously used for sorting');
+      expect(fileNameHeader.children().length).toEqual(1, 'Sorting indicator not added to the column used for sorting');
     }));
 
   it(

--- a/src/components/toggle/demo/index.html
+++ b/src/components/toggle/demo/index.html
@@ -17,14 +17,14 @@
 
 <body ng-app="demoApp">
 
-  <h1 class="ms-font-su">Toggle Demo | &lt;uif-toggle&gt;</h1> 
+  <h1 class="ms-font-su">Toggle Demo | &lt;uif-toggle&gt;</h1>
   <em>In order for this demo to work you must first build the library in debug mode.</em>
-  
+
   <h2>Default Toggle</h2>
   <p>
     This markup: <br />
     <code>
-    &lt;uif-toggle uif-label-off=&quot;Label off&quot; uif-label-on=&quot;Label on&quot; ng-model=&quot;toggled&quot;/&gt;  
+    &lt;uif-toggle uif-label-off=&quot;Label off&quot; uif-label-on=&quot;Label on&quot; ng-model=&quot;toggled&quot;/&gt;
     </code>
   </p>
 
@@ -32,10 +32,10 @@
     Renders this:
     <br />
     <uif-toggle uif-label-off="Label off" uif-label-on="Label on" ng-model="toggled"/>
-    
+
   </p>
   <p>
-    Toggled: {{toggled}}  
+    Toggled: {{toggled}}
   </p>
 
   <h2>Default Toogle with text location left</h2>
@@ -52,7 +52,22 @@
     <br />
     <uif-label>Toggle Control</uif-label>
     <uif-toggle uif-label-off="Label off" uif-label-on="Label on" uif-text-location="left"/>
-    
+
+  </p>
+
+  <h2>Toggle with transcluded label</h2>
+
+  <p>
+    This markup: <br />
+    <code>
+      &lt;uif-toggle uif-label-off=&quot;No&quot; uif-label-on=&quot;Yes&quot; ng-model=&quot;toggled&quot;&gt;Toggle this, or not&lt;/uif-toggle&gt;
+    </code>
+  </p>
+
+  <p>
+    Renders this:
+    <br />
+    <uif-toggle uif-label-off="No" uif-label-on="Yes" ng-model="toggled">Toggle this, or not</uif-toggle>
   </p>
 
   <h2>Disabled Toggle</h2>
@@ -67,11 +82,12 @@
     Renders this:
     <br />
     <uif-toggle uif-label-off="Label off" uif-label-on="Label on" ng-disabled="disabled"/>
-    
+
   </p>
   <p>
     <input type="checkbox" ng-model="disabled" />Disabled
   </p>
+
 </body>
 
 </html>

--- a/src/components/toggle/toggleDirective.spec.ts
+++ b/src/components/toggle/toggleDirective.spec.ts
@@ -34,17 +34,17 @@ describe('toggleDirective: <uif-toggle />', () => {
         $scope.toggled = true;
 
         let toggle: JQuery = $compile('<uif-toggle uif-label-off="No" uif-label-on="Yes" ' +
-                                                  'ng-model="toggled">Toggle this, or not</toggle>')($scope);
+                                                  'ng-model="toggled">Toggle this, or not</uif-toggle>')($scope);
         toggle = jQuery(toggle[0]);
         $scope.$apply();
 
         let labelOff: JQuery = toggle.find('.ms-Label--off');
         let labelOn: JQuery = toggle.find('.ms-Label--on');
-        let descLabel: JQuery = toggle.find('.ms-Toggle-description span');
+        let descLabel: JQuery = toggle.find('span.ms-Toggle-description');
 
         expect(labelOff.html()).toBe('No');
         expect(labelOn.html()).toBe('Yes');
-        expect(descLabel.html()).toBe('Toggle this, or not');
+        expect(descLabel.html()).toContain('Toggle this, or not');
     }));
 
     it('should be able to toggle', inject(($compile: Function, $rootScope: angular.IRootScopeService) => {


### PR DESCRIPTION
Updated Angular library dependency to 1.6.2.
Fixed all failing tests by either updating the tests and/or updating the directives.

Most (all?) failures were coming from the fact that angular is now not adding dummy `span` element with `ng-scope` class. Tests have been expecting this SPAN to be present, thus selectors were not returning proper elements and/or assertions on children count were offset by 1 mostly.

In `uif-button` directive I had to change the way labels are handled, because previously label was considered to be a `span`, but that's not longer the case.

Fix for each directive has separate commit for easier review (I hope @andrewconnell will forgive me 😄  )