### PR TITLE
Fixes Issue #487

### DIFF
--- a/src/components/dropdown/dropdownDirective.ts
+++ b/src/components/dropdown/dropdownDirective.ts
@@ -68,7 +68,7 @@ export class DropdownOptionDirective implements angular.IDirective {
     instanceElement
       .on('click', (ev: JQueryEventObject) => {
         scope.$apply(() => {
-          dropdownController.setViewValue(instanceElement.html(), attrs.value, ev);
+          dropdownController.setViewValue(instanceElement.text(), attrs.value, ev);
         });
       });
     let value: string = '' + dropdownController.getViewValue();
@@ -129,7 +129,7 @@ export class DropdownController {
           let option: HTMLElement = options[i];
           let value: string = option.getAttribute('value');
           if (value === self.$scope.ngModel.$viewValue) {
-            self.$scope.selectedTitle = angular.element(option).html();
+            self.$scope.selectedTitle = angular.element(option).text();
             found = true;
             break;
           }


### PR DESCRIPTION
Changed `.html()` to `.text()` on two lines in the dropdown component, which prevents the encoded "&amp;amp;" issue described in issue 487. The dropdown component displays the selected option value with interpolation, so the current use of `.html()` cannot be properly utilized without ng-bind-html and ngSanitize anyway.

Closes #487 