### PR TITLE
docs(): fix typos in documentation

### DIFF
--- a/docs/guides/CODING.md
+++ b/docs/guides/CODING.md
@@ -25,7 +25,7 @@ The components within the ngOfficeUIFabric are organized as follows:
 │   │   │   ├── index.html
 │   │   │   └── index.ts
 │   │   ├── <component>Directive.spec.ts
-│   │   ├── <component>Directive.ts
+│   │   └── <component>Directive.ts
 │   └── icon
 │       ├── demo
 │       │   ├── index.html
@@ -42,7 +42,7 @@ The components within the ngOfficeUIFabric are organized as follows:
     └── core.ts
 ```
 
-All components will depend on the `core.ts` file which contains the shared assets in the library. The `components.ts` file contains the `officeuidabric.components` module declaration which consumers can use to import all components rather than one at a time.
+All components will depend on the `core.ts` file which contains the shared assets in the library. The `components.ts` file contains the `officeuifabric.components` module declaration which consumers can use to import all components rather than one at a time.
 
 Each component should have at least a `demo` folder that contains the HTML & script that demonstrates how the component can be used. This should be a fully working sample. Additional demo folders can be provided for alternate implementations of the component. use the naming convention `demo[..]` for these alternate implementations. In addition, feel free to include a `README.md` within the demo folders for additional explanation when warranted.
 
@@ -152,7 +152,7 @@ The type must be one of the following options. This is used to explain what was 
 
 ### Scope
 
-Anything specifying the place of the commit change. This is not always required and can be left blank, but in those causes leave an empty parents `()`.
+Anything specifying the place of the commit change. This is not always required and can be left blank, but in those cases leave an empty parents `()`.
 
 ### Subject
 

--- a/docs/guides/CONTRIB-WORKFLOW.md
+++ b/docs/guides/CONTRIB-WORKFLOW.md
@@ -45,4 +45,4 @@ The following is recommended for contributing to the repo:
   > **NOTE**: Refer to the **[PULL-REQUESTS](PULL-REQUESTS.md)** page for more details on this.
 
 
-It is OK to create your PR as a "WIP" (work in progress) on the upstream repo before the implementation is done. This can be useful if you'd like to start the feedback process concurrent with your implementation. **State this this is the case in the initial PR comment.**
+It is OK to create your PR as a "WIP" (work in progress) on the upstream repo before the implementation is done. This can be useful if you'd like to start the feedback process concurrent with your implementation. **State that this is the case in the initial PR comment.**


### PR DESCRIPTION
The changes are self-explanatory, so didn't include a body in the commit message. Guides indicate not to open an issue for typos so there's no footer.

Additionally, wanted to clarify if `parents` on Line 155 of [CODING.MD](https://github.com/ngOfficeUIFabric/ng-officeuifabric/blob/master/docs/guides/CODING.md) was intentional or a typo for `parens` or `parentheses`.