### PR TITLE
DatePicker bugfix for issue #485

### DIFF
--- a/src/components/datepicker/datepickerDirective.ts
+++ b/src/components/datepicker/datepickerDirective.ts
@@ -192,7 +192,7 @@ export class DatepickerController {
       let currentDate: Pickadate.DateItem = $picker.get('highlight');
       let newYear: number = currentDate.year;
       let newMonth: number = +$(this).attr('data-month');
-      let newDay: number = currentDate.day;
+      let newDay: number = currentDate.date;
 
       /** Update the date. */
       self.changeHighlightedDate(newYear, newMonth, newDay);
@@ -212,7 +212,7 @@ export class DatepickerController {
       let currentDate: Pickadate.DateItem = $picker.get('highlight');
       let newYear: number = +$(this).attr('data-year');
       let newMonth: number = currentDate.month;
-      let newDay: number = currentDate.day;
+      let newDay: number = currentDate.date;
 
       /** Update the date. */
       self.changeHighlightedDate(newYear, newMonth, newDay);


### PR DESCRIPTION
I noticed issue 485 (using the month picker to change months multiple times will eventually cause the year to unexpectedly decrease) a while ago and finally got a chance to dig to figure out what was at fault. In both the click events for the month picker and the year picker, the DatePicker component is using the `.day` (day of the week) property, rather than `.date` (day of the month) property to set the new date. pickadate.js expects a day of the month integer value between 1-31 to set the date, while the day of the week values it is currently receiving are 0-6.

After changing both lines to `.date`, the year no longer changes when choosing months. Solves issue #485.

Plunk: https://plnkr.co/9rEH1FldEfNDxHbnqgof
