### PR TITLE
Allow newer versions of angularjs to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-officeuifabric-source",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Angular directives for Microsoft's Office UI Fabric.",
   "license": "MIT",
   "author": {
@@ -53,7 +53,7 @@
     "commit": "git-cz"
   },
   "dependencies": {
-    "angular": "1.6.4",
+    "angular": "^1.6.4",
     "office-ui-fabric": "2.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Update dependencies in package.json to support never minor versions of angularjs, not just 1.6.4